### PR TITLE
make foreign key nullable for ON DELETE SET NULL & add migration test to CI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,6 +19,7 @@ jobs:
           MYSQL_DATABASE: testdb
         ports:
           - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
       - uses: actions/checkout@v3
@@ -57,9 +58,9 @@ jobs:
 
       - name: Run alembic migration test
         env:
-          DB_USERNAME: root
-          DB_PASSWORD: root-password
-          DB_HOST: mysql
+          DB_USERNAME: test-user
+          DB_PASSWORD: password
+          DB_HOST: localhost
           DB_PORT: 3306
           DB_NAME: testdb
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -69,5 +69,5 @@ jobs:
           echo DB_HOST=$DB_HOST >> .env.local
           echo DB_PORT=$DB_PORT >> .env.local
           echo DB_NAME=$DB_NAME >> .env.local
-          alembic revision --autogenerate
-          alembic upgrade head
+          poetry run alembic revision --autogenerate
+          poetry run alembic upgrade head

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,12 +32,20 @@ jobs:
           python-version: 3.11
           cache: poetry
 
-      - name: Set poetry environment
+      - name: Set poetry environment & install dependencies
         run: |
           poetry env use 3.11
+          poetry install --no-root
 
-      - name: Install dependencies
-        run: poetry install --no-root
+      - name: create .env.local
+        run: |
+          touch .env.local
+          mkdir -p wacruit/src/database/migrations/versions
+          echo DB_USERNAME=test-user >> .env.local
+          echo DB_PASSWORD=password >> .env.local
+          echo DB_HOST=127.0.0.1 >> .env.local
+          echo DB_PORT=3306 >> .env.local
+          echo DB_NAME=testdb >> .env.local
 
       - name: Run tests
         run: |
@@ -57,19 +65,6 @@ jobs:
           poetry run pylint -rn -sn --rcfile=${GITHUB_WORKSPACE}/.pylintrc ./wacruit
 
       - name: Run alembic migration test
-        env:
-          DB_USERNAME: test-user
-          DB_PASSWORD: password
-          DB_HOST: 127.0.0.1
-          DB_PORT: 3306
-          DB_NAME: testdb
         run: |
-          touch .env.local
-          mkdir -p wacruit/src/database/migrations/versions
-          echo DB_USERNAME=$DB_USERNAME >> .env.local
-          echo DB_PASSWORD=$DB_PASSWORD >> .env.local
-          echo DB_HOST=$DB_HOST >> .env.local
-          echo DB_PORT=$DB_PORT >> .env.local
-          echo DB_NAME=$DB_NAME >> .env.local
           poetry run alembic revision --autogenerate
           poetry run alembic upgrade head

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,11 +57,11 @@ jobs:
 
       - name: Run alembic migration test
         env:
-          - DB_USERNAME: root
-          - DB_PASSWORD: root-password
-          - DB_HOST: localhost
-          - DB_PORT: 3306
-          - DB_NAME: testdb
+          DB_USERNAME: root
+          DB_PASSWORD: root-password
+          DB_HOST: localhost
+          DB_PORT: 3306
+          DB_NAME: testdb
         run: |
           touch .env.local
           echo DB_USERNAME=$DB_USERNAME >> .env.local

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,6 +9,16 @@ on:
 jobs:
   pytest:
     runs-on: ubuntu-latest
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_USER: test-user
+          MYSQL_PASSWORD: password
+          MYSQL_ROOT_PASSWORD: root-password
+          MYSQL_DATABASE: testdb
+        ports:
+          - 3306
 
     steps:
       - uses: actions/checkout@v3
@@ -44,3 +54,20 @@ jobs:
       - name: Check Pylint
         run: |
           poetry run pylint -rn -sn --rcfile=${GITHUB_WORKSPACE}/.pylintrc ./wacruit
+
+      - name: Run alembic migration test
+        env:
+          - DB_USERNAME: root
+          - DB_PASSWORD: root-password
+          - DB_HOST: localhost
+          - DB_PORT: 3306
+          - DB_NAME: testdb
+        run: |
+          touch .env.local
+          echo DB_USERNAME=$DB_USERNAME >> .env.local
+          echo DB_PASSWORD=$DB_PASSWORD >> .env.local
+          echo DB_HOST=$DB_HOST >> .env.local
+          echo DB_PORT=$DB_PORT >> .env.local
+          echo DB_NAME=$DB_NAME >> .env.local
+          alembic revision --autogenerate
+          alembic upgrade head

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,6 +65,7 @@ jobs:
           DB_NAME: testdb
         run: |
           touch .env.local
+          mkdir -p wacruit/src/database/migrations/versions
           echo DB_USERNAME=$DB_USERNAME >> .env.local
           echo DB_PASSWORD=$DB_PASSWORD >> .env.local
           echo DB_HOST=$DB_HOST >> .env.local

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
         env:
           DB_USERNAME: test-user
           DB_PASSWORD: password
-          DB_HOST: localhost
+          DB_HOST: 127.0.0.1
           DB_PORT: 3306
           DB_NAME: testdb
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
           MYSQL_ROOT_PASSWORD: root-password
           MYSQL_DATABASE: testdb
         ports:
-          - 3306
+          - 3306:3306
 
     steps:
       - uses: actions/checkout@v3
@@ -59,7 +59,7 @@ jobs:
         env:
           DB_USERNAME: root
           DB_PASSWORD: root-password
-          DB_HOST: localhost
+          DB_HOST: mysql
           DB_PORT: 3306
           DB_NAME: testdb
         run: |

--- a/wacruit/src/apps/problem/models.py
+++ b/wacruit/src/apps/problem/models.py
@@ -31,9 +31,11 @@ class CodeSubmission(DeclarativeBase):
     __tablename__ = "code_submission"
 
     id: Mapped[intpk]
-    user_id: Mapped[int] = mapped_column(ForeignKey("user.id", ondelete="SET NULL"))
+    user_id: Mapped[int | None] = mapped_column(
+        ForeignKey("user.id", ondelete="SET NULL")
+    )
     user: Mapped["User"] = relationship(back_populates="code_submissions")
-    problem_id: Mapped[int] = mapped_column(
+    problem_id: Mapped[int | None] = mapped_column(
         ForeignKey("problem.id", ondelete="SET NULL")
     )
     problem: Mapped["Problem"] = relationship(back_populates="submissions")
@@ -49,7 +51,7 @@ class TestCase(DeclarativeBase):
 
     id: Mapped[intpk]
     problem_id: Mapped[int] = mapped_column(
-        ForeignKey("problem.id", onupdate="SET NULL")
+        ForeignKey("problem.id", ondelete="CASCADE")
     )
     problem: Mapped["Problem"] = relationship(back_populates="testcases")
     stdin: Mapped[str] = mapped_column(Text, nullable=False)

--- a/wacruit/src/apps/problem/models.py
+++ b/wacruit/src/apps/problem/models.py
@@ -50,8 +50,8 @@ class TestCase(DeclarativeBase):
     __tablename__ = "testcase"
 
     id: Mapped[intpk]
-    problem_id: Mapped[int] = mapped_column(
-        ForeignKey("problem.id", ondelete="CASCADE")
+    problem_id: Mapped[int | None] = mapped_column(
+        ForeignKey("problem.id", ondelete="SET NULL")
     )
     problem: Mapped["Problem"] = relationship(back_populates="testcases")
     stdin: Mapped[str] = mapped_column(Text, nullable=False)

--- a/wacruit/src/tests/conftest.py
+++ b/wacruit/src/tests/conftest.py
@@ -1,4 +1,3 @@
-import tempfile
 from typing import Iterable
 
 import pytest
@@ -6,19 +5,19 @@ import sqlalchemy
 from sqlalchemy import orm
 
 from wacruit.src.database.base import DeclarativeBase
+from wacruit.src.database.config import db_config
 
 
 @pytest.fixture(scope="session")
 def db_engine() -> Iterable[sqlalchemy.Engine]:
-    with tempfile.TemporaryDirectory() as tmpdirname:
-        url = f"sqlite:////{tmpdirname}/db.sqlite3"
-        engine = sqlalchemy.create_engine(url)
-        DeclarativeBase.metadata.create_all(bind=engine)
+    url = db_config.url
+    engine = sqlalchemy.create_engine(url)
+    DeclarativeBase.metadata.create_all(bind=engine)
 
-        try:
-            yield engine
-        finally:
-            engine.dispose()
+    try:
+        yield engine
+    finally:
+        engine.dispose()
 
 
 @pytest.fixture(scope="function")


### PR DESCRIPTION
`ondelete="SET NULL"` 로 되어있는데 정작 foreign key는 non-nullable이라 마이그레이션이 제대로 되지 않는 이슈가 있었습니다.
+) 하는 김에 CI에 migration test 추가했습니다.
+) pytest 시에 mysql 사용하도록 변경했습니다.