### PR TITLE
fix scheme isssue of static file via kong-gateway

### DIFF
--- a/wacruit/src/admin/__init__.py
+++ b/wacruit/src/admin/__init__.py
@@ -1,0 +1,7 @@
+from sqladmin import Admin as DefaultAdmin
+
+from wacruit.src.settings import settings
+
+from .applications import HttpsAdmin
+
+Admin = DefaultAdmin if settings.is_local or settings.is_test else HttpsAdmin

--- a/wacruit/src/admin/applications.py
+++ b/wacruit/src/admin/applications.py
@@ -1,0 +1,18 @@
+from sqladmin import Admin
+from starlette.requests import Request
+from starlette.templating import Jinja2Templates
+from starlette.templating import pass_context
+
+
+class HttpsAdmin(Admin):
+    @staticmethod
+    @pass_context
+    def https_url_for(context: dict, name: str, **path_params) -> str:
+        request: Request = context["request"]
+        url = request.url_for(name, **path_params)
+        return url.components.geturl().replace("http://", "https://")
+
+    def init_templating_engine(self) -> Jinja2Templates:
+        templates = super().init_templating_engine()
+        templates.env.globals["url_for"] = self.https_url_for
+        return templates

--- a/wacruit/src/app.py
+++ b/wacruit/src/app.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
-from sqladmin import Admin
 
+from wacruit.src.admin import Admin
 from wacruit.src.admin.auth import authentication_backend
 from wacruit.src.admin.views import admin_views
 from wacruit.src.apps.router import api_router


### PR DESCRIPTION
클러스터 환경에서 `HttpsAdmin` 을 사용해 jinja template 에서 http 대신 https 스키마를 사용하도록 하였습니다.

<img width="794" alt="image" src="https://github.com/wafflestudio/wacruit-server/assets/71511067/f4cb91dd-4c10-4447-9921-944f071476d0">

교체한 Admin 으로 실행했을 때 https로 잘 치환되는 것을 확인하였습니다.

물론 위 사진은 로컬에서도 강제로 `HttpsAdmin` 으로 실행한 것이고, 실제로 로컬에서는 기본 `Admin`, 배포 환경에서는 `HttpsAdmin` 으로 실행하도록 설정하였습니다.