### PR TITLE
Add `AdminUser` annotation and `TestClient`

### DIFF
--- a/wacruit/src/apps/announcement/views.py
+++ b/wacruit/src/apps/announcement/views.py
@@ -6,6 +6,7 @@ from wacruit.src.apps.announcement.exceptions import AnnouncementNotFound
 from wacruit.src.apps.announcement.schemas import AnnouncementCreateDto
 from wacruit.src.apps.announcement.schemas import AnnouncementDto
 from wacruit.src.apps.announcement.services import AnnouncementService
+from wacruit.src.apps.common.dependencies import AdminUser
 from wacruit.src.apps.common.exceptions import responses_from
 from wacruit.src.apps.common.schemas import ListResponse
 
@@ -22,20 +23,20 @@ async def list_announcements(
 
 @v1_router.post("/")
 async def create_announcement(
+    user: AdminUser,
     request: AnnouncementCreateDto,
     announcement_service: AnnouncementService = Depends(),
 ) -> AnnouncementDto:
-    # TODO: Add permission check
     return announcement_service.create_announcement(request)
 
 
 @v1_router.put("/{id}", responses=responses_from(AnnouncementNotFound))
 async def update_announcement(
     id: int,
+    user: AdminUser,
     request: AnnouncementCreateDto,
     announcement_service: AnnouncementService = Depends(),
 ) -> AnnouncementDto:
-    # TODO: Add permission check
     return announcement_service.update_announcement(id, request)
 
 
@@ -44,6 +45,7 @@ async def update_announcement(
 )
 async def delete_announcement(
     id: int,
+    user: AdminUser,
     announcement_service: AnnouncementService = Depends(),
 ):
     announcement_service.delete_announcement(id)

--- a/wacruit/src/apps/common/dependencies.py
+++ b/wacruit/src/apps/common/dependencies.py
@@ -4,7 +4,7 @@ from fastapi import Depends
 from fastapi import Security
 from fastapi.security import APIKeyHeader
 
-from wacruit.src.apps.user.exceptions import UserNotFoundException
+from wacruit.src.apps.user.exceptions import UserPermissionDeniedException
 from wacruit.src.apps.user.models import User
 from wacruit.src.apps.user.repositories import UserRepository
 
@@ -27,8 +27,18 @@ def get_current_user(
 ) -> User:
     user = user_repository.get_user_by_sso_id(waffle_user_id)
     if user is None:
-        raise UserNotFoundException
+        raise UserPermissionDeniedException
     return user
 
 
 CurrentUser = Annotated[User, Depends(get_current_user)]
+
+
+def get_admin_user(current_user: CurrentUser) -> User:
+    print(current_user.is_admin)
+    if not current_user.is_admin:
+        raise UserPermissionDeniedException
+    return current_user
+
+
+AdminUser = Annotated[User, Depends(get_admin_user)]

--- a/wacruit/src/apps/user/views.py
+++ b/wacruit/src/apps/user/views.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException
 from fastapi import Security
 from fastapi.security import APIKeyHeader
 
+from wacruit.src.apps.common.dependencies import AdminUser
 from wacruit.src.apps.common.dependencies import CurrentUser
 from wacruit.src.apps.user.models import User
 from wacruit.src.apps.user.repositories import UserRepository
@@ -31,11 +32,9 @@ def create_user(
 
 @v1_router.get("")
 def list_users(
+    admin_user: AdminUser,
     user_service: Annotated[UserService, Depends()],
-    # current_user: User = Depends(get_current_user),
 ):
-    # if not current_user.is_admin:
-    #     raise UserPermissionDeniedException
     return user_service.list_users()
 
 

--- a/wacruit/src/tests/announcement/conftest.py
+++ b/wacruit/src/tests/announcement/conftest.py
@@ -1,10 +1,45 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 import pytest
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.announcement.repositories import AnnouncementRepository
 from wacruit.src.apps.announcement.schemas import AnnouncementCreateDto
 from wacruit.src.apps.announcement.services import AnnouncementService
+from wacruit.src.apps.announcement.views import v1_router
+from wacruit.src.apps.user.models import User
+from wacruit.src.apps.user.repositories import UserRepository
 from wacruit.src.database.connection import Transaction
+
+
+@pytest.fixture
+def user(db_session: Session) -> User:
+    user = User(
+        sso_id="abcdef123",
+        first_name="Test",
+        last_name="User",
+        phone_number="010-0000-0000",
+        email="example@email.com",
+        is_admin=False,
+    )
+    db_session.add(user)
+    db_session.commit()
+    return user
+
+
+@pytest.fixture
+def admin_user(db_session: Session) -> User:
+    user = User(
+        sso_id="abcdef123",
+        first_name="Test",
+        last_name="User",
+        phone_number="010-0000-0000",
+        email="example@email.com",
+        is_admin=True,
+    )
+    db_session.add(user)
+    db_session.commit()
+    return user
 
 
 @pytest.fixture

--- a/wacruit/src/tests/announcement/test_announcement_views.py
+++ b/wacruit/src/tests/announcement/test_announcement_views.py
@@ -1,0 +1,33 @@
+from fastapi.testclient import TestClient
+
+from wacruit.src.apps.user.models import User
+
+
+def test_cant_create_announcement_if_not_admin(user: User, test_client: TestClient):
+    assert user.sso_id is not None
+    assert user.is_admin is False
+    response = test_client.post(
+        "/api/v1/announcements/",
+        json={
+            "title": "title",
+            "content": "content",
+        },
+        headers={"waffle-user-id": user.sso_id},
+    )
+    assert response.status_code == 403
+
+
+def test_can_create_announcement_if_admin(admin_user: User, test_client: TestClient):
+    assert admin_user.sso_id is not None
+    assert admin_user.is_admin is True
+    response = test_client.post(
+        "/api/v1/announcements/",
+        json={
+            "title": "title",
+            "content": "content",
+        },
+        headers={"waffle-user-id": admin_user.sso_id},
+    )
+    assert response.status_code == 200
+    assert response.json()["title"] == "title"
+    assert response.json()["content"] == "content"

--- a/wacruit/src/tests/conftest.py
+++ b/wacruit/src/tests/conftest.py
@@ -1,11 +1,15 @@
 from typing import Iterable
 
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
 import pytest
 import sqlalchemy
 from sqlalchemy import orm
 
+from wacruit.src.apps.router import api_router
 from wacruit.src.database.base import DeclarativeBase
 from wacruit.src.database.config import db_config
+from wacruit.src.database.connection import get_db_session
 from wacruit.src.settings import settings
 
 
@@ -45,3 +49,16 @@ def db_session(db_engine: sqlalchemy.Engine) -> Iterable[orm.Session]:
         session.close()
         transaction.rollback()
         connection.close()
+
+
+@pytest.fixture
+def test_client(db_session: orm.Session) -> TestClient:
+    app = FastAPI()
+    app.include_router(api_router)
+
+    def override_get_db_session():
+        return db_session
+
+    app.dependency_overrides[get_db_session] = override_get_db_session
+    client = TestClient(app)
+    return client


### PR DESCRIPTION
- `waffle-user-id`에 해당하는 유저가 없을경우 404가 아니라 403를 주도록 변경
- 어드민 권한이 필요한 API의 경우 `AdminUser` 추가 (근데 sqladmin 쓸거면 이 api가 왜 필요한건지 의문)
- 잘 작동하는지 확인하기 위해 TestClient 추가