### PR TITLE
Hotfix resume & user api

### DIFF
--- a/wacruit/src/apps/resume/schemas.py
+++ b/wacruit/src/apps/resume/schemas.py
@@ -10,7 +10,7 @@ from wacruit.src.database.base import intpk
 
 
 class ResumeQuestionDto(BaseModel):
-    recruiting_id: int
+    id: int
     question_num: int
     content: str
     content_limit: int

--- a/wacruit/src/apps/resume/views.py
+++ b/wacruit/src/apps/resume/views.py
@@ -14,7 +14,7 @@ from wacruit.src.apps.resume.services import ResumeService
 from wacruit.src.apps.user.dependencies import CurrentUser
 from wacruit.src.apps.user.exceptions import UserPermissionDeniedException
 
-v1_router = APIRouter(prefix="/v1/recruiting", tags=["resume"])
+v1_router = APIRouter(prefix="/v1/recruitings", tags=["resume"])
 
 
 @v1_router.get(

--- a/wacruit/src/apps/user/views.py
+++ b/wacruit/src/apps/user/views.py
@@ -24,7 +24,7 @@ from wacruit.src.apps.user.services import UserService
 v1_router = APIRouter(prefix="/v1/users", tags=["users"])
 
 
-@v1_router.get("")
+@v1_router.get("/check")
 def check_signup(
     waffle_user_id: Annotated[str, Header()],
     user_service: Annotated[UserService, Depends()],


### PR DESCRIPTION
* resume list api 에서 recruiting_id 대신 resume_id 제공해주도록 변경
* resume api prefix 변경 (`recruiting` -> `recruitings`)
  * recruitings api와 통일을 위함입니다.
* user `check_signup` api 의 엔드포인트 변경 (list 와 겹쳐서)