### PR TITLE
base64 지원

### DIFF
--- a/wacruit/src/apps/judge/repositories.py
+++ b/wacruit/src/apps/judge/repositories.py
@@ -8,7 +8,6 @@ from .schemas import JudgeCreateSubmissionRequest
 from .schemas import JudgeCreateSubmissionResponse
 from .schemas import JudgeGetSubmissionResponse
 
-DEFAULT_PARAMS = {"base64_encoded": False}
 # DEFAULT_FIELDS = "stdout,stderr,compile_output,message,status,time,memory"
 DEFAULT_FIELDS = "stdout,message,status,time,memory"
 
@@ -22,7 +21,7 @@ class JudgeApiRepository:
     ) -> JudgeCreateSubmissionResponse:
         res = await self.client.post(
             url="/submissions",
-            params=DEFAULT_PARAMS,
+            params={"base64_encoded": False},
             json=request.dict(),
             timeout=60,
         )
@@ -38,7 +37,7 @@ class JudgeApiRepository:
         batch_request_data = {"submissions": [request.dict() for request in requests]}
         res = await self.client.post(
             url="/submissions/batch",
-            params=DEFAULT_PARAMS,
+            params={"base64_encoded": False},
             json=batch_request_data,
             timeout=60,
         )
@@ -51,7 +50,10 @@ class JudgeApiRepository:
     async def get_submission(self, token: str) -> JudgeGetSubmissionResponse:
         res = await self.client.get(
             url=f"/submissions/{token}",
-            params={**DEFAULT_PARAMS, "fields": DEFAULT_FIELDS},
+            params={
+                "base64_encoded": True,
+                "fields": DEFAULT_FIELDS,
+            },
             timeout=60,
         )
         if res.status_code >= 400:
@@ -67,7 +69,11 @@ class JudgeApiRepository:
             tokens = ",".join(tokens)
         res = await self.client.get(
             url="/submissions/batch",
-            params={"tokens": tokens, **DEFAULT_PARAMS, "fields": DEFAULT_FIELDS},
+            params={
+                "tokens": tokens,
+                "base64_encoded": True,
+                "fields": DEFAULT_FIELDS,
+            },
             timeout=60,
         )
         if res.status_code >= 400:

--- a/wacruit/src/apps/judge/schemas.py
+++ b/wacruit/src/apps/judge/schemas.py
@@ -1,5 +1,8 @@
+from base64 import b64decode
+
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import validator
 
 from wacruit.src.apps.common.enums import JudgeSubmissionStatus
 
@@ -37,3 +40,14 @@ class JudgeGetSubmissionResponse(BaseModel):
     status: JudgeSubmissionStatusModel
     time: str | None
     memory: int | None
+
+    class Config:
+        json_encoders = {
+            JudgeSubmissionStatusModel: lambda v: v.decode() if v is not None else None
+        }
+
+    @validator("stdout", pre=True)
+    def stdout_validator(cls, v):
+        if v is None:
+            return None
+        return b64decode(v).decode("utf-8")


### PR DESCRIPTION
원래는 저장할 땐 base64 형태로 저장되고 `json()` 함수로 변환할 때만 base64 문자열을 디코딩하려고 했는데,
https://github.com/pydantic/pydantic/issues/2531
위 이슈에 보면 builtin / custom type 에는 적용이 안 되는 이슈가 있고 이건 v2부터 해결되었다고 해서 그냥 저장될 때 부터 validator로 디코딩해서 넣도록 했습니다.