### PR TITLE
recruiting 종료 시 제출 막기

### DIFF
--- a/wacruit/src/apps/problem/exceptions.py
+++ b/wacruit/src/apps/problem/exceptions.py
@@ -34,11 +34,3 @@ class TestcaseNotFoundException(WacruitException):
             status_code=404,
             detail="테스트케이스를 찾을 수 없습니다.\n지속적으로 문제가 발생하면 관리자에게 문의 부탁드립니다.",
         )
-
-
-class RecruitingClosedException(WacruitException):
-    def __init__(self):
-        super().__init__(
-            status_code=404,
-            detail="모집이 마감되었습니다.",
-        )

--- a/wacruit/src/apps/problem/exceptions.py
+++ b/wacruit/src/apps/problem/exceptions.py
@@ -34,3 +34,11 @@ class TestcaseNotFoundException(WacruitException):
             status_code=404,
             detail="테스트케이스를 찾을 수 없습니다.\n지속적으로 문제가 발생하면 관리자에게 문의 부탁드립니다.",
         )
+
+
+class RecruitingClosedException(WacruitException):
+    def __init__(self):
+        super().__init__(
+            status_code=404,
+            detail="모집이 마감되었습니다.",
+        )

--- a/wacruit/src/apps/problem/repositories.py
+++ b/wacruit/src/apps/problem/repositories.py
@@ -3,6 +3,7 @@ from typing import Iterable, Sequence
 from fastapi import Depends
 from sqlalchemy import select
 from sqlalchemy.orm import contains_eager
+from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.common.enums import CodeSubmissionStatus
@@ -34,6 +35,7 @@ class ProblemRepository:
             )
             .where(Problem.id == problem_id)
             .options(contains_eager(Problem.testcases))
+            .options(joinedload(Problem.recruiting))
         )
         return self.session.execute(query).scalar()
 

--- a/wacruit/src/apps/problem/services.py
+++ b/wacruit/src/apps/problem/services.py
@@ -59,12 +59,7 @@ class ProblemService(LoggingMixin):
         if problem is None:
             raise ProblemNotFoundException()
 
-        recruiting_is_open = problem.recruiting.is_active and (
-            problem.recruiting.from_date
-            < datetime.utcnow() + timedelta(hours=9)
-            < problem.recruiting.to_date
-        )
-        if not recruiting_is_open:
+        if not problem.recruiting.is_open:
             raise RecruitingClosedException()
 
         testcases = problem.testcases

--- a/wacruit/src/apps/problem/services.py
+++ b/wacruit/src/apps/problem/services.py
@@ -1,7 +1,4 @@
 import asyncio
-from datetime import datetime
-from datetime import timedelta
-from datetime import timezone
 from decimal import Decimal
 import json
 from typing import AsyncGenerator, Tuple
@@ -20,7 +17,6 @@ from wacruit.src.apps.judge.schemas import JudgeCreateSubmissionRequest
 from wacruit.src.apps.problem.exceptions import CodeSubmissionErrorException
 from wacruit.src.apps.problem.exceptions import CodeSubmissionFailedException
 from wacruit.src.apps.problem.exceptions import ProblemNotFoundException
-from wacruit.src.apps.problem.exceptions import RecruitingClosedException
 from wacruit.src.apps.problem.exceptions import TestcaseNotFoundException
 from wacruit.src.apps.problem.models import CodeSubmission
 from wacruit.src.apps.problem.repositories import ProblemRepository
@@ -30,6 +26,7 @@ from wacruit.src.apps.problem.schemas import ProblemResponse
 from wacruit.src.apps.problem.schemas import TokenStr
 from wacruit.src.apps.problem.utils import memory_handi
 from wacruit.src.apps.problem.utils import time_handi
+from wacruit.src.apps.recruiting.exceptions import RecruitingClosedException
 from wacruit.src.apps.user.models import User
 from wacruit.src.utils.mixins import LoggingMixin
 

--- a/wacruit/src/apps/recruiting/exceptions.py
+++ b/wacruit/src/apps/recruiting/exceptions.py
@@ -4,3 +4,8 @@ from wacruit.src.apps.common.exceptions import WacruitException
 class RecruitingNotFoundException(WacruitException):
     def __init__(self):
         super().__init__(404, "존재하지 않는 리크루팅입니다.")
+
+
+class RecruitingClosedException(WacruitException):
+    def __init__(self):
+        super().__init__(status_code=404, detail="모집이 마감되었습니다.")

--- a/wacruit/src/apps/recruiting/models.py
+++ b/wacruit/src/apps/recruiting/models.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime
@@ -42,6 +43,12 @@ class Recruiting(DeclarativeBase):
         back_populates="recruiting"
     )
     problems: Mapped[list["Problem"]] = relationship(back_populates="recruiting")
+
+    @property
+    def is_open(self):
+        return self.is_active and (
+            self.from_date < datetime.utcnow() + timedelta(hours=9) < self.to_date
+        )
 
     @property
     def problem_status(self):

--- a/wacruit/src/apps/recruiting/repositories.py
+++ b/wacruit/src/apps/recruiting/repositories.py
@@ -38,7 +38,11 @@ class RecruitingRepository:
         print(query)
         return self.session.execute(query).scalar_one()
 
-    def get_recruiting_by_id(
+    def get_recruiting_by_id(self, recruiting_id: int) -> Recruiting:
+        query = select(Recruiting).where(Recruiting.id == recruiting_id)
+        return self.session.execute(query).scalar_one()
+
+    def get_recruiting_with_code_submission_status_by_id(
         self, recruiting_id: int, user_id: int
     ) -> Recruiting | None:
         query = (

--- a/wacruit/src/apps/recruiting/services.py
+++ b/wacruit/src/apps/recruiting/services.py
@@ -59,8 +59,10 @@ class RecruitingService:
     def get_recruiting_by_id(
         self, recruiting_id: int, user: User
     ) -> RecruitingResponse:
-        recruiting = self.recruiting_repository.get_recruiting_by_id(
-            recruiting_id, user.id
+        recruiting = (
+            self.recruiting_repository.get_recruiting_with_code_submission_status_by_id(
+                recruiting_id, user.id
+            )
         )
         if recruiting is None:
             raise RecruitingNotFoundException()

--- a/wacruit/src/tests/resume/test_resume_service.py
+++ b/wacruit/src/tests/resume/test_resume_service.py
@@ -2,6 +2,7 @@ from pydantic import EmailStr
 import pytest
 import pytest_mock
 
+from wacruit.src.apps.recruiting.exceptions import RecruitingClosedException
 from wacruit.src.apps.recruiting.models import Recruiting
 from wacruit.src.apps.resume.models import ResumeQuestion
 from wacruit.src.apps.resume.models import ResumeSubmission
@@ -14,10 +15,10 @@ from wacruit.src.apps.user.services import UserService
 
 def test_get_questions(
     resume_service: ResumeService,
-    recruiting: Recruiting,
+    opened_recruiting: Recruiting,
     resume_questions: list[ResumeQuestion],
 ):
-    questions = resume_service.get_questions_by_recruiting_id(recruiting.id)
+    questions = resume_service.get_questions_by_recruiting_id(opened_recruiting.id)
     assert len(questions) == len(resume_questions)
     for i, question in enumerate(questions):
         assert question.id == resume_questions[i].id
@@ -31,7 +32,7 @@ def test_get_questions(
 def test_create_resume(
     user: User,
     resume_service: ResumeService,
-    recruiting: Recruiting,
+    opened_recruiting: Recruiting,
     resume_questions: list[ResumeQuestion],
 ):
     answers = list(f"Answer for question {i}" for i in range(len(resume_questions)))
@@ -44,14 +45,16 @@ def test_create_resume(
     )
     submissions = resume_service.create_resume(
         user_id=user.id,
-        recruiting_id=recruiting.id,
+        recruiting_id=opened_recruiting.id,
         resume_submissions=resume_submissions,
     )
     submissions_by_user_and_recruiting = (
-        resume_service.get_resumes_by_user_and_recruiting_id(user.id, recruiting.id)
+        resume_service.get_resumes_by_user_and_recruiting_id(
+            user.id, opened_recruiting.id
+        )
     )
     submissions_by_recruiting = resume_service.get_resumes_by_recruiting_id(
-        recruiting.id
+        opened_recruiting.id
     )
     assert len(submissions) == len(answers)
     assert submissions == submissions_by_user_and_recruiting
@@ -60,7 +63,7 @@ def test_create_resume(
         assert submission.user_id == user.id
         assert submission.user.first_name == user.first_name
         assert submission.question_id == resume_questions[i].id
-        assert submission.recruiting_id == recruiting.id
+        assert submission.recruiting_id == opened_recruiting.id
         assert submission.answer == answers[i]
 
 
@@ -69,7 +72,7 @@ def test_withdraw_resume(
     user: User,
     resume_service: ResumeService,
     user_service: UserService,
-    recruiting: Recruiting,
+    opened_recruiting: Recruiting,
     resume_questions: list[ResumeQuestion],
 ):
     mock_file_delete = mocker.patch(
@@ -95,16 +98,18 @@ def test_withdraw_resume(
     )
     submissions = resume_service.create_resume(
         user_id=user.id,
-        recruiting_id=recruiting.id,
+        recruiting_id=opened_recruiting.id,
         resume_submissions=resume_submissions,
     )
     assert len(submissions) == len(answers)
 
     # user withdraws resume
-    resume_service.withdraw_resume(user.id, recruiting.id)
+    resume_service.withdraw_resume(user.id, opened_recruiting.id)
     mock_file_delete.assert_called_once_with(user.id)
     submissions_by_user_and_recruiting = (
-        resume_service.get_resumes_by_user_and_recruiting_id(user.id, recruiting.id)
+        resume_service.get_resumes_by_user_and_recruiting_id(
+            user.id, opened_recruiting.id
+        )
     )
     assert len(submissions_by_user_and_recruiting) == 0
 
@@ -118,7 +123,7 @@ def test_withdraw_resume(
 def test_update_resumes(
     user: User,
     resume_service: ResumeService,
-    recruiting: Recruiting,
+    opened_recruiting: Recruiting,
     resume_questions: list[ResumeQuestion],
 ):
     # user initially creates resume
@@ -134,7 +139,7 @@ def test_update_resumes(
     )
     resume_service.create_resume(
         user_id=user.id,
-        recruiting_id=recruiting.id,
+        recruiting_id=opened_recruiting.id,
         resume_submissions=initial_resume_submissions,
     )
 
@@ -151,14 +156,16 @@ def test_update_resumes(
     )
     updated_submissions = resume_service.update_resumes(
         user_id=user.id,
-        recruiting_id=recruiting.id,
+        recruiting_id=opened_recruiting.id,
         resume_submissions=updated_resume_submissions,
     )
     assert len(updated_submissions) == len(new_answers)
 
     # retrieve the updated resumes and verify they match the new answers
     submissions_by_user_and_recruiting = (
-        resume_service.get_resumes_by_user_and_recruiting_id(user.id, recruiting.id)
+        resume_service.get_resumes_by_user_and_recruiting_id(
+            user.id, opened_recruiting.id
+        )
     )
 
     assert len(submissions_by_user_and_recruiting) == len(updated_submissions)
@@ -169,12 +176,14 @@ def test_update_resumes(
 def test_update_resumes_create_new_submission(
     user: User,
     resume_service: ResumeService,
-    recruiting: Recruiting,
+    opened_recruiting: Recruiting,
     resume_questions: list[ResumeQuestion],
 ):
     # user has not submitted any resume
     submissions_by_user_and_recruiting = (
-        resume_service.get_resumes_by_user_and_recruiting_id(user.id, recruiting.id)
+        resume_service.get_resumes_by_user_and_recruiting_id(
+            user.id, opened_recruiting.id
+        )
     )
     assert len(submissions_by_user_and_recruiting) == 0
 
@@ -189,7 +198,7 @@ def test_update_resumes_create_new_submission(
     )
     updated_submissions = resume_service.update_resumes(
         user_id=user.id,
-        recruiting_id=recruiting.id,
+        recruiting_id=opened_recruiting.id,
         resume_submissions=new_resume_submissions,
     )
 
@@ -197,9 +206,40 @@ def test_update_resumes_create_new_submission(
 
     # retrieve the new resumes and verify they match the new answers
     submissions_by_user_and_recruiting = (
-        resume_service.get_resumes_by_user_and_recruiting_id(user.id, recruiting.id)
+        resume_service.get_resumes_by_user_and_recruiting_id(
+            user.id, opened_recruiting.id
+        )
     )
 
     assert len(submissions_by_user_and_recruiting) == len(updated_submissions)
     for i, submission in enumerate(submissions_by_user_and_recruiting):
         assert submission.answer == new_answers[i]
+
+
+def test_create_resume_for_closed_recruiting(
+    user: User,
+    resume_service: ResumeService,
+    closed_recruiting: Recruiting,
+    resume_questions: list[ResumeQuestion],
+):
+    answers = list(f"Answer for question {i}" for i in range(len(resume_questions)))
+    resume_submissions = list(
+        ResumeSubmissionCreateDto(
+            question_id=question.id,
+            answer=answer,
+        )
+        for question, answer in zip(resume_questions, answers)
+    )
+    with pytest.raises(RecruitingClosedException):
+        resume_service.create_resume(
+            user_id=user.id,
+            recruiting_id=closed_recruiting.id,
+            resume_submissions=resume_submissions,
+        )
+
+    with pytest.raises(RecruitingClosedException):
+        resume_service.update_resumes(
+            user_id=user.id,
+            recruiting_id=closed_recruiting.id,
+            resume_submissions=resume_submissions,
+        )


### PR DESCRIPTION
생각해보니 이 로직이 없어서.. 프론트에서 막더라도 dev tools 등으로 api 따서 제출하는 게 가능하기 때문에 아예 제출 막는 로직을 추가했습니다.
