### PR TITLE
Refactoring: Admin view 기능 강화 및 RecruitingApplicationAdmin 추가

### DIFF
--- a/wacruit/src/admin/views.py
+++ b/wacruit/src/admin/views.py
@@ -29,6 +29,12 @@ class UserAdmin(ModelView, model=User):
         User.college,
     ]
 
+    form_excluded_columns = [
+        User.code_submissions,
+        User.resume_submissions,
+        User.application,
+    ]
+
 
 class AnnouncementAdmin(ModelView, model=Announcement):
     column_list = [
@@ -41,6 +47,11 @@ class AnnouncementAdmin(ModelView, model=Announcement):
     ]
 
     column_formatters = {Announcement.content: shorten_column(width=20)}
+
+    form_excluded_columns = [
+        Announcement.created_at,
+        Announcement.updated_at,
+    ]
 
 
 class RecruitingAdmin(ModelView, model=Recruiting):
@@ -56,6 +67,13 @@ class RecruitingAdmin(ModelView, model=Recruiting):
 
     column_formatters = {Recruiting.description: shorten_column(width=20)}
 
+    form_excluded_columns = [
+        Recruiting.resume_submissions,
+        Recruiting.resume_questions,
+        Recruiting.problems,
+        Recruiting.applicants,
+    ]
+
 
 class ProblemAdmin(ModelView, model=Problem):
     column_list = [
@@ -69,6 +87,12 @@ class ProblemAdmin(ModelView, model=Problem):
         Problem.recruiting: recruiting_formatter,
         Problem.body: shorten_column(width=20),
     }
+
+    form_excluded_columns = [
+        Problem.submissions,
+        Problem.code_submissions,
+        Problem.testcases,
+    ]
 
 
 class CodeSubmissionAdmin(ModelView, model=CodeSubmission):
@@ -84,6 +108,11 @@ class CodeSubmissionAdmin(ModelView, model=CodeSubmission):
     column_formatters = {
         CodeSubmission.user: user_formatter,
     }
+
+    form_excluded_columns = [
+        CodeSubmission.results,
+        CodeSubmission.created_at,
+    ]
 
 
 class TestcaseAdmin(ModelView, model=Testcase):
@@ -102,6 +131,10 @@ class TestcaseAdmin(ModelView, model=Testcase):
         Testcase.expected_output: shorten_column(),
     }
 
+    form_excluded_columns = [
+        Testcase.submission_results,
+    ]
+
 
 class ResumeQuestionAdmin(ModelView, model=ResumeQuestion):
     column_list = [
@@ -116,6 +149,12 @@ class ResumeQuestionAdmin(ModelView, model=ResumeQuestion):
         ResumeQuestion.recruiting: recruiting_formatter,
         ResumeQuestion.content: shorten_column(width=20),
     }
+
+    form_excluded_columns = [
+        ResumeQuestion.created_at,
+        ResumeQuestion.updated_at,
+        ResumeQuestion.resume_submissions,
+    ]
 
 
 class ResumeSubmissionAdmin(ModelView, model=ResumeSubmission):
@@ -136,6 +175,11 @@ class ResumeSubmissionAdmin(ModelView, model=ResumeSubmission):
         ResumeSubmission.recruiting: recruiting_formatter,
         ResumeSubmission.question: question_formatter,
     }
+
+    form_excluded_columns = [
+        ResumeSubmission.created_at,
+        ResumeSubmission.updated_at,
+    ]
 
 
 admin_views = [

--- a/wacruit/src/admin/views.py
+++ b/wacruit/src/admin/views.py
@@ -35,6 +35,16 @@ class UserAdmin(ModelView, model=User):
         User.application,
     ]
 
+    column_searchable_list = [
+        User.first_name,
+        User.last_name,
+        User.email,
+        User.phone_number,
+        User.department,
+        User.university,
+        User.college,
+    ]
+
 
 class AnnouncementAdmin(ModelView, model=Announcement):
     column_list = [
@@ -51,6 +61,11 @@ class AnnouncementAdmin(ModelView, model=Announcement):
     form_excluded_columns = [
         Announcement.created_at,
         Announcement.updated_at,
+    ]
+
+    column_searchable_list = [
+        Announcement.title,
+        Announcement.content,
     ]
 
 
@@ -74,6 +89,11 @@ class RecruitingAdmin(ModelView, model=Recruiting):
         Recruiting.applicants,
     ]
 
+    column_searchable_list = [
+        Recruiting.name,
+        Recruiting.description,
+    ]
+
 
 class ProblemAdmin(ModelView, model=Problem):
     column_list = [
@@ -94,6 +114,11 @@ class ProblemAdmin(ModelView, model=Problem):
         Problem.testcases,
     ]
 
+    column_searchable_list = [
+        Problem.num,
+        Problem.body,
+    ]
+
 
 class CodeSubmissionAdmin(ModelView, model=CodeSubmission):
     column_list = [
@@ -112,6 +137,12 @@ class CodeSubmissionAdmin(ModelView, model=CodeSubmission):
     form_excluded_columns = [
         CodeSubmission.results,
         CodeSubmission.created_at,
+    ]
+
+    column_searchable_list = [
+        CodeSubmission.user_id,
+        CodeSubmission.language,
+        CodeSubmission.status,
     ]
 
 
@@ -135,6 +166,12 @@ class TestcaseAdmin(ModelView, model=Testcase):
         Testcase.submission_results,
     ]
 
+    column_searchable_list = [
+        Testcase.problem_id,
+        Testcase.stdin,
+        Testcase.expected_output,
+    ]
+
 
 class ResumeQuestionAdmin(ModelView, model=ResumeQuestion):
     column_list = [
@@ -154,6 +191,11 @@ class ResumeQuestionAdmin(ModelView, model=ResumeQuestion):
         ResumeQuestion.created_at,
         ResumeQuestion.updated_at,
         ResumeQuestion.resume_submissions,
+    ]
+
+    column_searchable_list = [
+        ResumeQuestion.question_num,
+        ResumeQuestion.content,
     ]
 
 
@@ -179,6 +221,11 @@ class ResumeSubmissionAdmin(ModelView, model=ResumeSubmission):
     form_excluded_columns = [
         ResumeSubmission.created_at,
         ResumeSubmission.updated_at,
+    ]
+
+    column_searchable_list = [
+        ResumeSubmission.user_id,
+        ResumeSubmission.answer,
     ]
 
 

--- a/wacruit/src/admin/views.py
+++ b/wacruit/src/admin/views.py
@@ -11,6 +11,7 @@ from wacruit.src.apps.problem.models import CodeSubmission
 from wacruit.src.apps.problem.models import Problem
 from wacruit.src.apps.problem.models import Testcase
 from wacruit.src.apps.recruiting.models import Recruiting
+from wacruit.src.apps.recruiting.models import RecruitingApplication
 from wacruit.src.apps.resume.models import ResumeQuestion
 from wacruit.src.apps.resume.models import ResumeSubmission
 from wacruit.src.apps.user.models import User
@@ -229,6 +230,26 @@ class ResumeSubmissionAdmin(ModelView, model=ResumeSubmission):
     ]
 
 
+class RecruitingApplicationAdmin(ModelView, model=RecruitingApplication):
+    column_list = [
+        RecruitingApplication.id,
+        RecruitingApplication.recruiting,
+        RecruitingApplication.user,
+        RecruitingApplication.status,
+        RecruitingApplication.created_at,
+    ]
+
+    column_formatters = {
+        RecruitingApplication.recruiting: recruiting_formatter,
+        RecruitingApplication.user: user_formatter,
+    }
+
+    form_excluded_columns = [
+        RecruitingApplication.created_at,
+        RecruitingApplication.updated_at,
+    ]
+
+
 admin_views = [
     UserAdmin,
     RecruitingAdmin,
@@ -238,4 +259,5 @@ admin_views = [
     TestcaseAdmin,
     ResumeQuestionAdmin,
     ResumeSubmissionAdmin,
+    RecruitingApplicationAdmin,
 ]


### PR DESCRIPTION
## 변경 사항
* `Announcement` 등을 admin view에서 추가할 때, `created_at`, `updated_at` 등을 직접 입력해주어야하는 이슈가 있었는데, DB 기본값인 `CURRENT TIMESTAMP` 를 사용하도록 admin form에서 제거했습니다.
  * 그 외에도 의미 없는 역참조 필드들을 폼에서 안 보이도록 제거했습니다. (예: 문제 생성 폼에서 다른 문제를 참조하는 테스트케이스들의 목록이 더 이상 보이지 않음)

## 추가 기능
* 각 admin view 에서 적절한 컬럼들을 선정하여 검색하는 기능을 추가했습니다.
* `RecruitingApplicationAdmin` view를 추가했습니다.