### PR TITLE
Add pre-commit test to test.yaml

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -61,7 +61,7 @@ jobs:
       - name: Run pre-commit
         run: |
           git fetch origin ${{ github.base_ref }} ${{ github.head_ref }}
-          poetry run pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD
+          poetry run pre-commit run --from-ref ${{ github.base_ref }} --to-ref ${{ github.head_ref }}
 
       - name: Run alembic migration test
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,8 +60,8 @@ jobs:
       # it contains pylint, black, isort, etc.
       - name: Run pre-commit
         run: |
-          git fetch origin ${{ github.base_ref }} ${{ github.head_ref }}
-          poetry run pre-commit run --from-ref ${{ github.base_ref }} --to-ref ${{ github.head_ref }}
+          git fetch origin ${{ github.base_ref }}
+          poetry run pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD
 
       - name: Run alembic migration test
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
       # it contains pylint, black, isort, etc.
       - name: Run pre-commit
         run: |
-          git fetch origin ${{ github.base_ref }} ${{ github.head_ref }}
+          git pull origin ${{ github.base_ref }} ${{ github.head_ref }}
           poetry run pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD
 
       - name: Run alembic migration test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,9 +56,11 @@ jobs:
           path: "./wacruit/test.xml"
           reporter: java-junit
 
-      - name: Check Pylint
+      # run pre-commit only different from base branch
+      # it contains pylint, black, isort, etc.
+      - name: Run pre-commit
         run: |
-          poetry run pylint -rn -sn --rcfile=${GITHUB_WORKSPACE}/.pylintrc ./wacruit
+          poetry run pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD
 
       - name: Run alembic migration test
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,8 +60,8 @@ jobs:
       # it contains pylint, black, isort, etc.
       - name: Run pre-commit
         run: |
-          git fetch origin ${{ github.base_ref }}
-          poetry run pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.head_ref }}
+          git fetch origin ${{ github.base_ref }} ${{ github.head_ref }}
+          poetry run pre-commit run --from-ref ${{ github.base_ref }} --to-ref ${{ github.head_ref }}
 
       - name: Run alembic migration test
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,8 +60,8 @@ jobs:
       # it contains pylint, black, isort, etc.
       - name: Run pre-commit
         run: |
-          git fetch origin ${{ github.base_ref }} ${{ github.head_ref }}
-          poetry run pre-commit run --from-ref ${{ github.base_ref }} --to-ref ${{ github.head_ref }}
+          git fetch origin ${{ github.base_ref }}
+          poetry run pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref ${{ github.head_ref }}
 
       - name: Run alembic migration test
         run: |

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
       # it contains pylint, black, isort, etc.
       - name: Run pre-commit
         run: |
-          git fetch origin ${{ github.base_ref }} ${{ github.ref_name }}
+          git fetch origin ${{ github.base_ref }} ${{ github.head_ref }}
           poetry run pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD
 
       - name: Run alembic migration test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,6 +60,7 @@ jobs:
       # it contains pylint, black, isort, etc.
       - name: Run pre-commit
         run: |
+          git fetch origin ${{ github.base_ref }} ${{ github.ref_name }}
           poetry run pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD
 
       - name: Run alembic migration test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -60,7 +60,7 @@ jobs:
       # it contains pylint, black, isort, etc.
       - name: Run pre-commit
         run: |
-          git pull origin ${{ github.base_ref }} ${{ github.head_ref }}
+          git fetch origin ${{ github.base_ref }} ${{ github.head_ref }}
           poetry run pre-commit run --from-ref origin/${{ github.base_ref }} --to-ref HEAD
 
       - name: Run alembic migration test


### PR DESCRIPTION
PR 대상 브랜치와 비교하여 달라진 파일들에 대해 pre-commit 테스트를 github action 에서 수행하도록 변경합니다.
실수로든 아니면 환경 문제든 pre-commit 설치 하지 않거나 못하는 경우를 위해 작성했습니다.