### PR TITLE
포트폴리오 v2 API 명세 및 로직 개선

### DIFF
--- a/wacruit/src/apps/portfolio/file/aws/s3/client.py
+++ b/wacruit/src/apps/portfolio/file/aws/s3/client.py
@@ -1,11 +1,16 @@
+from typing import cast
+
 import boto3
+from botocore.client import BaseClient
 
 from wacruit.src.utils.singleton import SingletonMeta
 
 
 class S3Client(metaclass=SingletonMeta):
+    _client: BaseClient
+
     def __init__(self, region_name: str = "ap-northeast-2"):
-        self._client = boto3.client("s3", region_name=region_name)
+        self._client = cast(BaseClient, boto3.client("s3", region_name=region_name))
 
     @property
     def client(self):

--- a/wacruit/src/apps/portfolio/file/exceptions.py
+++ b/wacruit/src/apps/portfolio/file/exceptions.py
@@ -9,8 +9,3 @@ class NumPortfolioLimitException(WacruitException):
 class PortfolioNotFoundException(WacruitException):
     def __init__(self):
         super().__init__(status_code=404, detail="포트폴리오를 찾을 수 없습니다.")
-
-
-class InValidGenerationException(WacruitException):
-    def __init__(self):
-        super().__init__(status_code=404, detail="유효하지 않은 기수입니다.")

--- a/wacruit/src/apps/portfolio/file/views_v2.py
+++ b/wacruit/src/apps/portfolio/file/views_v2.py
@@ -48,8 +48,8 @@ def get_download_portfolio_url(
     )
 
 
-@v2_router.get(
-    path="/url/upload/",
+@v2_router.post(
+    path="/url/upload",
     responses=responses_from(NumPortfolioLimitException),
     status_code=HTTPStatus.OK,
 )
@@ -73,32 +73,11 @@ def get_upload_portfolio_url(
 def check_upload_portfolio_completed(
     current_user: CurrentUser,
     portfolio_file_id: int,
-    request: PortfolioFileRequest,
     service: Annotated[PortfolioFileService, fastapi.Depends()],
 ) -> PortfolioFileResponse:
     return service.register_portfolio_file_info_in_db(
         user_id=current_user.id,
         portfolio_file_id=portfolio_file_id,
-        file_name=request.file_name,
-        recruiting_id=request.recruiting_id,
-    )
-
-
-@v2_router.get(
-    path="/url/check-upload-completed/update/{portfolio_file_id}",
-    responses=responses_from(NumPortfolioLimitException),
-    status_code=HTTPStatus.OK,
-)
-def check_updated_upload_portfolio_completed(
-    current_user: CurrentUser,
-    portfolio_file_id: int,
-    request: PortfolioFileRequest,
-    service: Annotated[PortfolioFileService, fastapi.Depends()],
-) -> PortfolioFileResponse:
-    return service.update_portfolio_file_info_in_db(
-        user_id=current_user.id,
-        portfolio_file_id=portfolio_file_id,
-        new_file_name=request.file_name,
     )
 
 

--- a/wacruit/src/apps/portfolio/url/exceptions.py
+++ b/wacruit/src/apps/portfolio/url/exceptions.py
@@ -14,8 +14,3 @@ class PortfolioUrlNotAuthorized(WacruitException):
 class PortfolioUrlNotFound(WacruitException):
     def __init__(self):
         super().__init__(status_code=404, detail="존재하지 않는 URL입니다.")
-
-
-class InValidGenerationException(WacruitException):
-    def __init__(self):
-        super().__init__(status_code=404, detail="유효하지 않은 기수입니다.")

--- a/wacruit/src/apps/recruiting/exceptions.py
+++ b/wacruit/src/apps/recruiting/exceptions.py
@@ -8,7 +8,7 @@ class RecruitingNotFoundException(WacruitException):
 
 class RecruitingClosedException(WacruitException):
     def __init__(self):
-        super().__init__(status_code=404, detail="모집이 마감되었습니다.")
+        super().__init__(status_code=403, detail="모집이 마감되었습니다.")
 
 
 class RecruitingNotAppliedException(WacruitException):

--- a/wacruit/src/apps/recruiting/repositories.py
+++ b/wacruit/src/apps/recruiting/repositories.py
@@ -8,6 +8,8 @@ from sqlalchemy.orm import Session
 
 from wacruit.src.apps.problem.models import CodeSubmission
 from wacruit.src.apps.problem.models import Problem
+from wacruit.src.apps.recruiting.exceptions import RecruitingClosedException
+from wacruit.src.apps.recruiting.exceptions import RecruitingNotFoundException
 from wacruit.src.apps.recruiting.models import Recruiting
 from wacruit.src.apps.recruiting.models import RecruitingApplication
 from wacruit.src.database.connection import get_db_session
@@ -70,3 +72,10 @@ class RecruitingRepository:
             .where(RecruitingApplication.user_id == user_id)
         )
         return self.session.execute(query).scalar()
+
+    def validate_recruiting_id(self, recruiting_id: int) -> None:
+        recruiting = self.get_recruiting_by_id(recruiting_id)
+        if recruiting is None:
+            raise RecruitingNotFoundException
+        if not recruiting.is_open:
+            raise RecruitingClosedException

--- a/wacruit/src/tests/portfolio/file/test_portfolio_file_service.py
+++ b/wacruit/src/tests/portfolio/file/test_portfolio_file_service.py
@@ -55,7 +55,7 @@ def test_register_portfolio_file_v2(
         recruiting_id=recruiting1.id,
     )
     response = portfolio_file_service.register_portfolio_file_info_in_db(
-        user1.id, response.portfolio_file_id, "test1.pdf", recruiting1.id
+        user1.id, response.portfolio_file_id
     )
     first_id = response.id
     expected = PortfolioFileResponse(
@@ -73,7 +73,7 @@ def test_register_portfolio_file_v2(
             recruiting_id=recruiting1.id,
         )
         portfolio_file_service.register_portfolio_file_info_in_db(
-            user1.id, response.portfolio_file_id, "test2.pdf", recruiting1.id
+            user1.id, response.portfolio_file_id
         )
 
     response = portfolio_file_service.get_presigned_url_for_post_portfolio(
@@ -82,7 +82,7 @@ def test_register_portfolio_file_v2(
         recruiting_id=recruiting2.id,
     )
     portfolio_file_service.register_portfolio_file_info_in_db(
-        user1.id, response.portfolio_file_id, "test3.pdf", recruiting2.id
+        user1.id, response.portfolio_file_id
     )
 
     response = portfolio_file_service.list_portfolios_from_db(
@@ -98,16 +98,6 @@ def test_register_portfolio_file_v2(
         ),
     ]
     assert response == expected, response
-    response = portfolio_file_service.update_portfolio_file_info_in_db(
-        user_id=user1.id, portfolio_file_id=first_id, new_file_name="test2.pdf"
-    )
-    expected = PortfolioFileResponse(
-        id=first_id,
-        file_name="test2.pdf",
-        recruiting_id=recruiting1.id,
-        is_uploaded=True,
-    )
-    assert response == expected
 
 
 def test_get_download_portfolio_file_url_v2(
@@ -121,7 +111,7 @@ def test_get_download_portfolio_file_url_v2(
         recruiting_id=recruiting1.id,
     )
     portfolio_file_service.register_portfolio_file_info_in_db(
-        user1.id, response.portfolio_file_id, "test1.pdf", recruiting1.id
+        user1.id, response.portfolio_file_id
     )
     response = portfolio_file_service.get_presigned_url_for_get_portfolio(
         user_id=user1.id,
@@ -149,7 +139,7 @@ def test_delete_portfolio_file_v2(
     )
 
     portfolio_file_service.register_portfolio_file_info_in_db(
-        user1.id, response.portfolio_file_id, "test1.pdf", recruiting1.id
+        user1.id, response.portfolio_file_id
     )
     s3_client = portfolio_file_service._s3_client.client
     s3_client.create_bucket(


### PR DESCRIPTION
- validate_recruiting_id 중복 로직 개선
- 중복 Exception 로직 개선
- 사용하지 않는 api 제거
- /v2/file/url/upload 메소드 변경 및 trailing slash 제거
- check-upload-completed 는 portfolio_file_id 만 넘기도록 변경
- portfolio url update 시에 열려있는 리크루팅인지 확인하도록 변경
- portfolio url 불러올 때 열려있는 리크루팅인지 확인하지 않도록 변경