### PR TITLE
feat: SSE 기본 ping 이벤트 사실 상 제거 / CodeSubmission 에러 조건 추가

### DIFF
--- a/wacruit/src/apps/problem/services_v2.py
+++ b/wacruit/src/apps/problem/services_v2.py
@@ -148,8 +148,10 @@ class ProblemService(LoggingMixin):
             response = await self.hodu_api_repository.submit(hodu_request)
             if isinstance(response, HoduSubmitResponse):
                 submission_result_status = response.status.to_submission_result_status()
-                if submission_result_status != CodeSubmissionResultStatus.CORRECT:
+                if submission_result_status != CodeSubmissionResultStatus.CORRECT and submission_result_status != CodeSubmissionResultStatus.INTERNAL_SERVER_ERROR:
                     merge_status(CodeSubmissionStatus.WRONG)
+                elif submission_result_status == CodeSubmissionResultStatus.INTERNAL_SERVER_ERROR:
+                    merge_status(CodeSubmissionStatus.ERROR)
                 self.problem_repository.update_submission_result(
                     submission_result,
                     submission_result_status,

--- a/wacruit/src/apps/problem/views_v2.py
+++ b/wacruit/src/apps/problem/views_v2.py
@@ -58,5 +58,5 @@ async def get_submission(
     problem_service: Annotated[ProblemService, Depends()],
 ):
     return EventSourceResponse(
-        problem_service.get_recent_submission_result(request, user, problem_id)
+        problem_service.get_recent_submission_result(request, user, problem_id), ping=3600
     )


### PR DESCRIPTION
- SSE 기본 ping 이벤트 간격 3600초로 변경
- CodeSubmissionResult 가 INTERNAL_SERVER_ERROR 일 때 CodeSubmission 를 Error로 판단