### PR TITLE
Fix: portfolio file service

### DIFF
--- a/wacruit/src/apps/portfolio/file/services.py
+++ b/wacruit/src/apps/portfolio/file/services.py
@@ -122,8 +122,10 @@ class PortfolioFileService(LoggingMixin):
             s3_bucket=self._s3_config.bucket_name,
             s3_prefix="",
         )
-        return list(set(
-            int(obj.split("/")[0]) 
-            for obj in objects 
-            if "/" in obj and obj.split("/")[0].isdigit()
-        ))
+        return list(
+            set(
+                int(obj.split("/")[0])
+                for obj in objects
+                if "/" in obj and obj.split("/")[0].isdigit()
+            )
+        )


### PR DESCRIPTION
- portfolio file service의  get_all_applicant_user_ids함수에서 s3 파일명에 맨 앞에 숫자만 담긴 것만 포함되도록 수정했습니다.