### PR TITLE
후원자 정렬 (#136)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,3 +79,4 @@ select = ["E", "F", "W", "I", "PL"]
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true
+force-single-line = true

--- a/wacruit/src/apps/common/enums.py
+++ b/wacruit/src/apps/common/enums.py
@@ -116,3 +116,10 @@ class TimelineGroupType(Enum):
     ROOKIE = "ROOKIE"
     PROGRAMMER = "PROGRAMMER"
     DESIGNER = "DESIGNER"
+
+
+class SponsorOrder(str, Enum):
+    AMOUNT_ASC = "amount"
+    AMOUNT_DESC = "-amount"
+    DATE_ASC = "date"
+    DATE_DESC = "-date"

--- a/wacruit/src/apps/sponsor/repositories.py
+++ b/wacruit/src/apps/sponsor/repositories.py
@@ -1,9 +1,15 @@
+from typing import Optional
+from typing import Sequence
+
 from fastapi import Depends
+from sqlalchemy import extract
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
+from wacruit.src.apps.common.enums import SponsorOrder
 from wacruit.src.apps.sponsor.models import Sponsor
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class SponsorRepository:
@@ -26,8 +32,27 @@ class SponsorRepository:
     def get_sponsor_by_id(self, sponsor_id: int) -> Sponsor | None:
         return self.session.query(Sponsor).filter(Sponsor.id == sponsor_id).first()
 
-    def get_all_sponsors(self) -> list[Sponsor]:
-        return self.session.query(Sponsor).all()
+    def get_all_sponsors(
+        self, order: Optional[SponsorOrder] = None, year: Optional[int] = None
+    ) -> Sequence[Sponsor]:
+        stmt = select(Sponsor)
+
+        if year is not None:
+            stmt = stmt.where(extract("year", Sponsor.sponsored_date) == year)
+
+        if order is not None:
+            order_map = {
+                "amount": Sponsor.amount.asc(),
+                "-amount": Sponsor.amount.desc(),
+                "date": Sponsor.sponsored_date.asc(),
+                "-date": Sponsor.sponsored_date.desc(),
+            }
+
+            sort_condition = order_map.get(order)
+            if sort_condition is not None:
+                stmt = stmt.order_by(sort_condition)
+
+        return self.session.execute(stmt).scalars().all()
 
     def update_sponsor(self, sponsor: Sponsor):
         with self.transaction:

--- a/wacruit/src/apps/sponsor/schemas.py
+++ b/wacruit/src/apps/sponsor/schemas.py
@@ -27,6 +27,7 @@ class SponsorInfoResponse(OrmModel):
 class SponsorBriefResponse(OrmModel):
     id: int
     name: str
+    sponsored_date: date
 
 
 class SponsorUpdateRequest(BaseModel):

--- a/wacruit/src/apps/sponsor/services.py
+++ b/wacruit/src/apps/sponsor/services.py
@@ -1,7 +1,9 @@
 from typing import Annotated
+from typing import Optional
 
 from fastapi import Depends
 
+from wacruit.src.apps.common.enums import SponsorOrder
 from wacruit.src.apps.common.schemas import ListResponse
 from wacruit.src.apps.sponsor.exceptions import SponsorAlreadyExistsException
 from wacruit.src.apps.sponsor.exceptions import SponsorNotFoundException
@@ -35,8 +37,11 @@ class SponsorService:
             raise SponsorNotFoundException
         return SponsorInfoResponse.from_orm(sponsor)
 
-    def get_all_sponsors(self) -> ListResponse[SponsorBriefResponse]:
-        sponsors = self.sponsor_repository.get_all_sponsors()
+    def get_all_sponsors(
+        self, order: Optional[SponsorOrder] = None, year: Optional[int] = None
+    ) -> ListResponse[SponsorBriefResponse]:
+        sponsors = self.sponsor_repository.get_all_sponsors(order, year)
+
         return (
             ListResponse[SponsorBriefResponse](
                 items=[SponsorBriefResponse.from_orm(sponsor) for sponsor in sponsors]

--- a/wacruit/src/apps/sponsor/views.py
+++ b/wacruit/src/apps/sponsor/views.py
@@ -1,9 +1,11 @@
 from typing import Annotated
+from typing import Optional
 
 from fastapi import APIRouter
 from fastapi import Depends
-from fastapi import Response
+from fastapi import Query
 
+from wacruit.src.apps.common.enums import SponsorOrder
 from wacruit.src.apps.common.schemas import ListResponse
 from wacruit.src.apps.sponsor.schemas import SponsorBriefResponse
 from wacruit.src.apps.sponsor.schemas import SponsorCreateRequest
@@ -36,8 +38,16 @@ def get_sponsor(
 @v3_router.get("")
 def get_all_sponsors(
     sponsor_service: Annotated[SponsorService, Depends()],
+    order: Annotated[
+        Optional[SponsorOrder],
+        Query(
+            description="sorting order(e.g. amount, -amount, date, -date), "
+            "'-' prefix for descending order"
+        ),
+    ] = None,
+    year: Annotated[Optional[int], Query(description="sponsors by year")] = None,
 ) -> ListResponse[SponsorBriefResponse]:
-    return sponsor_service.get_all_sponsors()
+    return sponsor_service.get_all_sponsors(order, year)
 
 
 @v3_router.patch("/{sponsor_id}")


### PR DESCRIPTION
* ruff isort 설정을 import문이 단일 라인을 유지하도록 수정했습니다.
* 후원자 목록 조회에 정렬, 연도별 필터링을 추가했습니다.