### PR TITLE
Feature/pre registration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,6 @@ exclude = [
 ]
 venvPath = "."
 venv = ".venv"
-reportShadowedImports = false
 
 [tool.ruff]
 line-length = 88

--- a/wacruit/src/apps/announcement/__init__.py
+++ b/wacruit/src/apps/announcement/__init__.py
@@ -1,1 +1,5 @@
-from .views import v1_router as router
+from .views import v1_router
+
+router = v1_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/announcement/models.py
+++ b/wacruit/src/apps/announcement/models.py
@@ -2,8 +2,8 @@ from datetime import datetime
 
 from sqlalchemy import DateTime
 from sqlalchemy import String
-from sqlalchemy import text
 from sqlalchemy import Text
+from sqlalchemy import text
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 

--- a/wacruit/src/apps/announcement/repositories.py
+++ b/wacruit/src/apps/announcement/repositories.py
@@ -6,8 +6,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.announcement.models import Announcement
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class AnnouncementRepository:

--- a/wacruit/src/apps/common/schemas.py
+++ b/wacruit/src/apps/common/schemas.py
@@ -1,4 +1,7 @@
-from typing import Any, Generic, Iterable, TypeVar
+from typing import Any
+from typing import Generic
+from typing import Iterable
+from typing import TypeVar
 
 from pydantic import BaseModel
 from pydantic.generics import GenericModel

--- a/wacruit/src/apps/dummy/__init__.py
+++ b/wacruit/src/apps/dummy/__init__.py
@@ -1,1 +1,5 @@
-from .views import v1_router as router
+from .views import v1_router
+
+router = v1_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/faq/__init__.py
+++ b/wacruit/src/apps/faq/__init__.py
@@ -1,1 +1,5 @@
-from .views import v3_router as router
+from .views import v3_router
+
+router = v3_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/faq/repositories.py
+++ b/wacruit/src/apps/faq/repositories.py
@@ -4,8 +4,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.faq.models import FAQ
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class QuestionRepository:

--- a/wacruit/src/apps/faq/views.py
+++ b/wacruit/src/apps/faq/views.py
@@ -5,7 +5,6 @@ from fastapi import APIRouter
 from fastapi import Depends
 
 from wacruit.src.apps.common.schemas import ListResponse
-from wacruit.src.apps.faq.models import FAQ
 from wacruit.src.apps.faq.schemas import CreateQuestionRequest
 from wacruit.src.apps.faq.schemas import QuestionResponse
 from wacruit.src.apps.faq.schemas import UpdateQuestionRequest
@@ -17,7 +16,7 @@ v3_router = APIRouter(prefix="/v3/questions", tags=["questions"])
 
 @v3_router.get(path="", status_code=HTTPStatus.OK)
 def get_questions(
-    question_service: Annotated[QuestionService, Depends()]
+    question_service: Annotated[QuestionService, Depends()],
 ) -> ListResponse[QuestionResponse]:
     res = question_service.get_questions()
     items = []

--- a/wacruit/src/apps/history/__init__.py
+++ b/wacruit/src/apps/history/__init__.py
@@ -1,1 +1,5 @@
-from .views import v3_router as router
+from .views import v3_router
+
+router = v3_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/history/repositories.py
+++ b/wacruit/src/apps/history/repositories.py
@@ -2,13 +2,12 @@ from datetime import datetime
 from typing import List
 
 from fastapi import Depends
-from sqlalchemy import delete
 from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.history.models import History
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class HistoryRepository:

--- a/wacruit/src/apps/history/services.py
+++ b/wacruit/src/apps/history/services.py
@@ -1,5 +1,3 @@
-from datetime import datetime
-
 from fastapi import Depends
 
 from wacruit.src.apps.history.exceptions import HistoryNotFoundException

--- a/wacruit/src/apps/hodu/config.py
+++ b/wacruit/src/apps/hodu/config.py
@@ -1,4 +1,3 @@
-from fastapi.security import api_key
 from pydantic import BaseSettings
 
 from wacruit.src.secrets import OCISecretManager
@@ -9,7 +8,7 @@ class HoduAPIConfig(BaseSettings):
     url: str = ""
     api_key: str = ""
 
-    class Config:
+    class Config(BaseSettings.Config):
         case_sensitive = False
         env_prefix = "HODU_"
         env_file = settings.env_files

--- a/wacruit/src/apps/hodu/repositories.py
+++ b/wacruit/src/apps/hodu/repositories.py
@@ -1,5 +1,4 @@
 from datetime import timedelta
-from typing import Iterable
 
 from fastapi import Depends
 from httpx import AsyncClient
@@ -9,13 +8,14 @@ from tenacity import retry
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
 
-from wacruit.src.apps.hodu.schemas import HoduSubmitError
 from wacruit.src.apps.hodu.schemas import HoduSubmitErrorResponse
 from wacruit.src.apps.hodu.schemas import HoduSubmitRequest
 from wacruit.src.apps.hodu.schemas import HoduSubmitResponse
 from wacruit.src.utils.mixins import LoggingMixin
 
 from .connections import get_hodu_api_client
+
+HTTP_CLIENT_ERROR_STATUS_CODE = 400
 
 
 class HoduApiRepository(LoggingMixin):
@@ -37,7 +37,7 @@ class HoduApiRepository(LoggingMixin):
         self, response: Response
     ) -> HoduSubmitResponse | HoduSubmitErrorResponse:
         try:
-            if response.status_code >= 400:
+            if response.status_code >= HTTP_CLIENT_ERROR_STATUS_CODE:
                 self.logger.error(
                     "HODU API ERROR for sending %s / status code: %d / response: %s",
                     response.url,

--- a/wacruit/src/apps/hodu/schemas.py
+++ b/wacruit/src/apps/hodu/schemas.py
@@ -1,9 +1,5 @@
 from enum import StrEnum
-from subprocess import STDOUT
-from typing import Self
-from xmlrpc.client import INTERNAL_ERROR
 
-from MySQLdb import TIME
 from pydantic import BaseModel
 from pydantic import Field
 
@@ -68,43 +64,46 @@ class HoduSubmitStatus(StrEnum):
     INTERNAL_ERROR = "INTERNAL_ERROR"
 
     def to_submission_result_status(self) -> CodeSubmissionResultStatus:
-        match self:
-            case HoduSubmitStatus.CORRECT:
-                return CodeSubmissionResultStatus.CORRECT
-            case HoduSubmitStatus.WRONG:
-                return CodeSubmissionResultStatus.WRONG
-            case HoduSubmitStatus.COMPILE_ERROR:
-                return CodeSubmissionResultStatus.COMPILE_ERROR
-            case HoduSubmitStatus.RUNTIME_ERROR:
-                return CodeSubmissionResultStatus.RUNTIME_ERROR
-            case HoduSubmitStatus.TIME_LIMIT_EXCEEDED:
-                return CodeSubmissionResultStatus.TIME_LIMIT_EXCEEDED
-            case HoduSubmitStatus.MEMORY_LIMIT_EXCEEDED:
-                return CodeSubmissionResultStatus.MEMORY_LIMIT_EXCEEDED
-            case HoduSubmitStatus.INTERNAL_ERROR:
-                return CodeSubmissionResultStatus.INTERNAL_SERVER_ERROR
+        status_map = {
+            HoduSubmitStatus.CORRECT: CodeSubmissionResultStatus.CORRECT,
+            HoduSubmitStatus.WRONG: CodeSubmissionResultStatus.WRONG,
+            HoduSubmitStatus.COMPILE_ERROR: CodeSubmissionResultStatus.COMPILE_ERROR,
+            HoduSubmitStatus.RUNTIME_ERROR: CodeSubmissionResultStatus.RUNTIME_ERROR,
+            HoduSubmitStatus.TIME_LIMIT_EXCEEDED: (
+                CodeSubmissionResultStatus.TIME_LIMIT_EXCEEDED
+            ),
+            HoduSubmitStatus.MEMORY_LIMIT_EXCEEDED: (
+                CodeSubmissionResultStatus.MEMORY_LIMIT_EXCEEDED
+            ),
+            HoduSubmitStatus.INTERNAL_ERROR: (
+                CodeSubmissionResultStatus.INTERNAL_SERVER_ERROR
+            ),
+        }
+        return status_map[self]
 
     @staticmethod
     def from_submission_result_status(
         status: CodeSubmissionResultStatus,
     ) -> "HoduSubmitStatus":
-        match status:
-            case CodeSubmissionResultStatus.CORRECT:
-                return HoduSubmitStatus.CORRECT
-            case CodeSubmissionResultStatus.WRONG:
-                return HoduSubmitStatus.WRONG
-            case CodeSubmissionResultStatus.COMPILE_ERROR:
-                return HoduSubmitStatus.COMPILE_ERROR
-            case CodeSubmissionResultStatus.RUNTIME_ERROR:
-                return HoduSubmitStatus.RUNTIME_ERROR
-            case CodeSubmissionResultStatus.TIME_LIMIT_EXCEEDED:
-                return HoduSubmitStatus.TIME_LIMIT_EXCEEDED
-            case CodeSubmissionResultStatus.MEMORY_LIMIT_EXCEEDED:
-                return HoduSubmitStatus.MEMORY_LIMIT_EXCEEDED
-            case CodeSubmissionResultStatus.INTERNAL_SERVER_ERROR:
-                return HoduSubmitStatus.INTERNAL_ERROR
-            case _:
-                raise ValueError(f"Invalid CodeSubmissionResultStatus: {status}")
+        status_map = {
+            CodeSubmissionResultStatus.CORRECT: HoduSubmitStatus.CORRECT,
+            CodeSubmissionResultStatus.WRONG: HoduSubmitStatus.WRONG,
+            CodeSubmissionResultStatus.COMPILE_ERROR: HoduSubmitStatus.COMPILE_ERROR,
+            CodeSubmissionResultStatus.RUNTIME_ERROR: HoduSubmitStatus.RUNTIME_ERROR,
+            CodeSubmissionResultStatus.TIME_LIMIT_EXCEEDED: (
+                HoduSubmitStatus.TIME_LIMIT_EXCEEDED
+            ),
+            CodeSubmissionResultStatus.MEMORY_LIMIT_EXCEEDED: (
+                HoduSubmitStatus.MEMORY_LIMIT_EXCEEDED
+            ),
+            CodeSubmissionResultStatus.INTERNAL_SERVER_ERROR: (
+                HoduSubmitStatus.INTERNAL_ERROR
+            ),
+        }
+        try:
+            return status_map[status]
+        except KeyError as exc:
+            raise ValueError(f"Invalid CodeSubmissionResultStatus: {status}") from exc
 
 
 class HoduSubmitExtraFields(BaseModel):

--- a/wacruit/src/apps/judge/repositories.py
+++ b/wacruit/src/apps/judge/repositories.py
@@ -10,6 +10,7 @@ from .schemas import JudgeGetSubmissionResponse
 
 # DEFAULT_FIELDS = "stdout,stderr,compile_output,message,status,time,memory"
 DEFAULT_FIELDS = "stdout,message,status,time,memory"
+HTTP_CLIENT_ERROR_STATUS_CODE = 400
 
 
 class JudgeApiRepository:
@@ -25,7 +26,7 @@ class JudgeApiRepository:
             json=request.dict(),
             timeout=60,
         )
-        if res.status_code >= 400:
+        if res.status_code >= HTTP_CLIENT_ERROR_STATUS_CODE:
             print(f"ERROR for sending {res.url} / status code: {res.status_code}.")
             print(f"Details: {res.text}")
         res.raise_for_status()
@@ -41,7 +42,7 @@ class JudgeApiRepository:
             json=batch_request_data,
             timeout=60,
         )
-        if res.status_code >= 400:
+        if res.status_code >= HTTP_CLIENT_ERROR_STATUS_CODE:
             print(f"ERROR for sending {res.url} / status code: {res.status_code}.")
             print(f"Details: {res.text}")
         res.raise_for_status()
@@ -56,7 +57,7 @@ class JudgeApiRepository:
             },
             timeout=60,
         )
-        if res.status_code >= 400:
+        if res.status_code >= HTTP_CLIENT_ERROR_STATUS_CODE:
             print(f"ERROR for sending {res.url} / status code: {res.status_code}.")
             print(f"Details: {res.text}")
         res.raise_for_status()
@@ -76,7 +77,7 @@ class JudgeApiRepository:
             },
             timeout=60,
         )
-        if res.status_code >= 400:
+        if res.status_code >= HTTP_CLIENT_ERROR_STATUS_CODE:
             print(f"ERROR for sending {res.url} / status code: {res.status_code}.")
             print(f"Details: {res.text}")
         res.raise_for_status()

--- a/wacruit/src/apps/member/__init__.py
+++ b/wacruit/src/apps/member/__init__.py
@@ -1,1 +1,5 @@
-from .views import v3_router as router
+from .views import v3_router
+
+router = v3_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/member/models.py
+++ b/wacruit/src/apps/member/models.py
@@ -14,7 +14,6 @@ from wacruit.src.database.base import str50
 from wacruit.src.database.base import str255
 
 if TYPE_CHECKING:
-    from wacruit.src.apps.project.models import Project
     from wacruit.src.apps.review.models import Review
 
 

--- a/wacruit/src/apps/member/views.py
+++ b/wacruit/src/apps/member/views.py
@@ -4,7 +4,6 @@ from typing import Annotated
 from fastapi import APIRouter
 from fastapi import Depends
 from fastapi import Query
-from fastapi import Response
 from fastapi import Security
 from fastapi.security import APIKeyHeader
 

--- a/wacruit/src/apps/portfolio/file/aws/s3/client.py
+++ b/wacruit/src/apps/portfolio/file/aws/s3/client.py
@@ -4,7 +4,8 @@ import boto3
 from botocore.client import BaseClient
 from botocore.config import Config
 
-from wacruit.src.apps.portfolio.file.aws.config import StorageConfig, storage_config
+from wacruit.src.apps.portfolio.file.aws.config import StorageConfig
+from wacruit.src.apps.portfolio.file.aws.config import storage_config
 
 
 class S3Client:

--- a/wacruit/src/apps/portfolio/file/aws/s3/utils.py
+++ b/wacruit/src/apps/portfolio/file/aws/s3/utils.py
@@ -61,7 +61,7 @@ def generate_presigned_url(
     return url
 
 
-def generate_presigned_post_url(
+def generate_presigned_post_url(  # noqa: PLR0913
     s3_client: BaseClient,
     s3_bucket: str,
     s3_object: str,

--- a/wacruit/src/apps/portfolio/file/exceptions.py
+++ b/wacruit/src/apps/portfolio/file/exceptions.py
@@ -3,7 +3,9 @@ from wacruit.src.apps.common.exceptions import WacruitException
 
 class NumPortfolioLimitException(WacruitException):
     def __init__(self):
-        super().__init__(status_code=403, detail="포트폴리오는 최대 1개까지 업로드 가능합니다.")
+        super().__init__(
+            status_code=403, detail="포트폴리오는 최대 1개까지 업로드 가능합니다."
+        )
 
 
 class PortfolioNotFoundException(WacruitException):

--- a/wacruit/src/apps/portfolio/file/repositories.py
+++ b/wacruit/src/apps/portfolio/file/repositories.py
@@ -9,9 +9,8 @@ from sqlalchemy.orm import Session
 
 from wacruit.src.apps.portfolio.file.exceptions import PortfolioNotFoundException
 from wacruit.src.apps.portfolio.file.models import PortfolioFile
-from wacruit.src.database.base import intpk
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class PortfolioFileRepository:
@@ -30,7 +29,7 @@ class PortfolioFileRepository:
         query = select(PortfolioFile).where(
             (PortfolioFile.user_id == user_id)
             & (PortfolioFile.recruiting_id == recruiting_id)
-            & (PortfolioFile.is_uploaded == True)
+            & PortfolioFile.is_uploaded
         )
         return self.session.execute(query).scalars().all()
 

--- a/wacruit/src/apps/portfolio/file/services.py
+++ b/wacruit/src/apps/portfolio/file/services.py
@@ -1,20 +1,14 @@
 from wacruit.src.apps.portfolio.file.aws.config import storage_config
 from wacruit.src.apps.portfolio.file.aws.s3.client import S3Client
 from wacruit.src.apps.portfolio.file.aws.s3.method import S3PresignedUrlMethod
-from wacruit.src.apps.portfolio.file.aws.s3.utils import (
-    delete_object,
-    generate_presigned_post_url,
-    generate_presigned_url,
-    get_list_of_objects,
-)
-from wacruit.src.apps.portfolio.file.exceptions import (
-    NumPortfolioLimitException,
-    PortfolioNotFoundException,
-)
-from wacruit.src.apps.portfolio.file.schemas import (
-    PortfolioNameResponse,
-    PresignedUrlResponse,
-)
+from wacruit.src.apps.portfolio.file.aws.s3.utils import delete_object
+from wacruit.src.apps.portfolio.file.aws.s3.utils import generate_presigned_post_url
+from wacruit.src.apps.portfolio.file.aws.s3.utils import generate_presigned_url
+from wacruit.src.apps.portfolio.file.aws.s3.utils import get_list_of_objects
+from wacruit.src.apps.portfolio.file.exceptions import NumPortfolioLimitException
+from wacruit.src.apps.portfolio.file.exceptions import PortfolioNotFoundException
+from wacruit.src.apps.portfolio.file.schemas import PortfolioNameResponse
+from wacruit.src.apps.portfolio.file.schemas import PresignedUrlResponse
 from wacruit.src.utils.mixins import LoggingMixin
 
 _1_MIN = 60

--- a/wacruit/src/apps/portfolio/file/services_v2.py
+++ b/wacruit/src/apps/portfolio/file/services_v2.py
@@ -5,23 +5,17 @@ from fastapi import Depends
 from wacruit.src.apps.portfolio.file.aws.config import storage_config
 from wacruit.src.apps.portfolio.file.aws.s3.client import S3Client
 from wacruit.src.apps.portfolio.file.aws.s3.method import S3PresignedUrlMethod
-from wacruit.src.apps.portfolio.file.aws.s3.utils import (
-    delete_object,
-    generate_presigned_post_url,
-    generate_presigned_url,
-    get_list_of_objects,
-)
-from wacruit.src.apps.portfolio.file.exceptions import (
-    NumPortfolioLimitException,
-    PortfolioNotFoundException,
-)
+from wacruit.src.apps.portfolio.file.aws.s3.utils import delete_object
+from wacruit.src.apps.portfolio.file.aws.s3.utils import generate_presigned_post_url
+from wacruit.src.apps.portfolio.file.aws.s3.utils import generate_presigned_url
+from wacruit.src.apps.portfolio.file.aws.s3.utils import get_list_of_objects
+from wacruit.src.apps.portfolio.file.exceptions import NumPortfolioLimitException
+from wacruit.src.apps.portfolio.file.exceptions import PortfolioNotFoundException
 from wacruit.src.apps.portfolio.file.models import PortfolioFile
 from wacruit.src.apps.portfolio.file.repositories import PortfolioFileRepository
-from wacruit.src.apps.portfolio.file.schemas import (
-    PortfolioFileResponse,
-    PresignedUrlResponse,
-    PresignedUrlWithIdResponse,
-)
+from wacruit.src.apps.portfolio.file.schemas import PortfolioFileResponse
+from wacruit.src.apps.portfolio.file.schemas import PresignedUrlResponse
+from wacruit.src.apps.portfolio.file.schemas import PresignedUrlWithIdResponse
 from wacruit.src.apps.recruiting.repositories import RecruitingRepository
 from wacruit.src.utils.mixins import LoggingMixin
 

--- a/wacruit/src/apps/portfolio/file/views_v2.py
+++ b/wacruit/src/apps/portfolio/file/views_v2.py
@@ -9,7 +9,6 @@ from wacruit.src.apps.portfolio.file.exceptions import NumPortfolioLimitExceptio
 from wacruit.src.apps.portfolio.file.exceptions import PortfolioNotFoundException
 from wacruit.src.apps.portfolio.file.schemas import PortfolioFileRequest
 from wacruit.src.apps.portfolio.file.schemas import PortfolioFileResponse
-from wacruit.src.apps.portfolio.file.schemas import PortfolioRequest
 from wacruit.src.apps.portfolio.file.schemas import PresignedUrlResponse
 from wacruit.src.apps.portfolio.file.schemas import PresignedUrlWithIdResponse
 from wacruit.src.apps.portfolio.file.services_v2 import PortfolioFileService

--- a/wacruit/src/apps/portfolio/url/exceptions.py
+++ b/wacruit/src/apps/portfolio/url/exceptions.py
@@ -3,7 +3,9 @@ from wacruit.src.apps.common.exceptions import WacruitException
 
 class NumPortfolioUrlLimitException(WacruitException):
     def __init__(self):
-        super().__init__(status_code=403, detail="등록 가능한 Url 개수 한계를 초과하셨습니다.")
+        super().__init__(
+            status_code=403, detail="등록 가능한 Url 개수 한계를 초과하셨습니다."
+        )
 
 
 class PortfolioUrlNotAuthorized(WacruitException):

--- a/wacruit/src/apps/portfolio/url/repositories.py
+++ b/wacruit/src/apps/portfolio/url/repositories.py
@@ -9,8 +9,8 @@ from sqlalchemy.orm import Session
 from wacruit.src.apps.portfolio.url.exceptions import PortfolioUrlNotFound
 from wacruit.src.apps.portfolio.url.models import PortfolioUrl
 from wacruit.src.database.base import intpk
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class PortfolioUrlRepository:

--- a/wacruit/src/apps/pre_registration/__init__.py
+++ b/wacruit/src/apps/pre_registration/__init__.py
@@ -1,1 +1,5 @@
-from .views import v3_router as router
+from .views import v3_router
+
+router = v3_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/pre_registration/exceptions.py
+++ b/wacruit/src/apps/pre_registration/exceptions.py
@@ -3,14 +3,23 @@ from wacruit.src.apps.common.exceptions import WacruitException
 
 class PreRegistNotActiveException(WacruitException):
     def __init__(self):
-        super().__init__(status_code=404, detail="활성화된 사전 알림이 존재하지 않습니다.")
+        super().__init__(
+            status_code=404,
+            detail="활성화된 사전 등록이 존재하지 않습니다.",
+        )
 
 
 class PreRegistNotExistException(WacruitException):
     def __init__(self):
-        super().__init__(status_code=404, detail="해당하는 사전 알림이 존재하지 않습니다.")
+        super().__init__(
+            status_code=404,
+            detail="해당하는 사전 등록이 존재하지 않습니다.",
+        )
 
 
 class PreRegistAlreadyExistException(WacruitException):
     def __init__(self):
-        super().__init__(status_code=409, detail="활성화된 사전 알림이 이미 존재합니다.")
+        super().__init__(
+            status_code=409,
+            detail="활성화된 사전 등록이 이미 존재합니다.",
+        )

--- a/wacruit/src/apps/pre_registration/exceptions.py
+++ b/wacruit/src/apps/pre_registration/exceptions.py
@@ -23,3 +23,11 @@ class PreRegistAlreadyExistException(WacruitException):
             status_code=409,
             detail="활성화된 사전 등록이 이미 존재합니다.",
         )
+
+
+class PreRegistUserAlreadyExistException(WacruitException):
+    def __init__(self):
+        super().__init__(
+            status_code=409,
+            detail="이미 사전 등록한 이메일입니다.",
+        )

--- a/wacruit/src/apps/pre_registration/models.py
+++ b/wacruit/src/apps/pre_registration/models.py
@@ -1,15 +1,63 @@
+from sqlalchemy import CheckConstraint
+from sqlalchemy import ForeignKey
+from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import Mapped
+from sqlalchemy.orm import mapped_column
+from sqlalchemy.orm import relationship
+from sqlalchemy.orm import validates
 
 from wacruit.src.database.base import DeclarativeBase
 from wacruit.src.database.base import intpk
 from wacruit.src.database.base import str30
+from wacruit.src.database.base import str50
 from wacruit.src.database.base import str255
 
 
 class PreRegistration(DeclarativeBase):
     __tablename__ = "pre_registration"
+    __table_args__ = (
+        UniqueConstraint("active_key", name="uk_pre_registration_active"),
+        CheckConstraint(
+            "active_key IS NULL OR active_key = 1",
+            name="ck_pre_registration_active_key",
+        ),
+    )
 
     id: Mapped[intpk]
     url: Mapped[str255]
     generation: Mapped[str30]
     is_active: Mapped[bool]
+    active_key: Mapped[int | None] = mapped_column(default=None, nullable=True)
+
+    users: Mapped[list["PreRegistrationUser"]] = relationship(
+        back_populates="pre_registration"
+    )
+
+    @validates("is_active")
+    def validate_is_active(self, _key: str, is_active: bool) -> bool:
+        self.active_key = 1 if is_active else None
+        return is_active
+
+
+class PreRegistrationUser(DeclarativeBase):
+    __tablename__ = "pre_registration_user"
+    __table_args__ = (
+        UniqueConstraint(
+            "pre_registration_id",
+            "email",
+            name="uk_pre_registration_user_email",
+        ),
+    )
+
+    id: Mapped[intpk]
+    pre_registration_id: Mapped[int] = mapped_column(
+        ForeignKey("pre_registration.id", ondelete="CASCADE"), nullable=False
+    )
+    name: Mapped[str50]
+    email: Mapped[str255]
+    phone_number: Mapped[str30]
+    university: Mapped[str50 | None]
+    college: Mapped[str50 | None]
+    department: Mapped[str50 | None]
+
+    pre_registration: Mapped["PreRegistration"] = relationship(back_populates="users")

--- a/wacruit/src/apps/pre_registration/repositories.py
+++ b/wacruit/src/apps/pre_registration/repositories.py
@@ -63,7 +63,7 @@ class PreRegistrationRepository:
         self,
         pre_registration_id: int | None,
         active_only: bool,
-        limit: int,
+        limit: int | None,
         offset: int,
     ) -> list[PreRegistrationUser]:
         query = select(PreRegistrationUser).join(PreRegistration)
@@ -73,7 +73,7 @@ class PreRegistrationRepository:
             )
         if active_only:
             query = query.where(PreRegistration.is_active == true())
-        query = (
-            query.order_by(PreRegistrationUser.id.desc()).limit(limit).offset(offset)
-        )
+        query = query.order_by(PreRegistrationUser.id.desc()).offset(offset)
+        if limit is not None:
+            query = query.limit(limit)
         return list(self.session.execute(query).scalars())

--- a/wacruit/src/apps/pre_registration/repositories.py
+++ b/wacruit/src/apps/pre_registration/repositories.py
@@ -5,8 +5,8 @@ from sqlalchemy import true
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.pre_registration.models import PreRegistration
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class PreRegistrationRepository:
@@ -46,6 +46,7 @@ class PreRegistrationRepository:
         return pre_registration
 
     def delete_pre_registration(self, pre_registration_id: int) -> None:
-        self.session.execute(
-            delete(PreRegistration).where(PreRegistration.id == pre_registration_id)
-        )
+        with self.transaction:
+            self.session.execute(
+                delete(PreRegistration).where(PreRegistration.id == pre_registration_id)
+            )

--- a/wacruit/src/apps/pre_registration/repositories.py
+++ b/wacruit/src/apps/pre_registration/repositories.py
@@ -5,6 +5,7 @@ from sqlalchemy import true
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.pre_registration.models import PreRegistration
+from wacruit.src.apps.pre_registration.models import PreRegistrationUser
 from wacruit.src.database.connection import Transaction
 from wacruit.src.database.connection import get_db_session
 
@@ -50,3 +51,29 @@ class PreRegistrationRepository:
             self.session.execute(
                 delete(PreRegistration).where(PreRegistration.id == pre_registration_id)
             )
+
+    def create_pre_registration_user(
+        self, pre_registration_user: PreRegistrationUser
+    ) -> PreRegistrationUser:
+        with self.transaction:
+            self.session.add(pre_registration_user)
+        return pre_registration_user
+
+    def get_pre_registration_users(
+        self,
+        pre_registration_id: int | None,
+        active_only: bool,
+        limit: int,
+        offset: int,
+    ) -> list[PreRegistrationUser]:
+        query = select(PreRegistrationUser).join(PreRegistration)
+        if pre_registration_id is not None:
+            query = query.where(
+                PreRegistrationUser.pre_registration_id == pre_registration_id
+            )
+        if active_only:
+            query = query.where(PreRegistration.is_active == true())
+        query = (
+            query.order_by(PreRegistrationUser.id.desc()).limit(limit).offset(offset)
+        )
+        return list(self.session.execute(query).scalars())

--- a/wacruit/src/apps/pre_registration/schemas.py
+++ b/wacruit/src/apps/pre_registration/schemas.py
@@ -57,7 +57,7 @@ class SendPreRegistrationEmailRequest(BaseModel):
 
 
 class SendPreRegistrationEmailResponse(BaseModel):
+    status: str
     total_count: int
-    success_count: int
-    failed_count: int
-    failed_emails: list[str]
+    queued_count: int
+    recipient_limit: int

--- a/wacruit/src/apps/pre_registration/schemas.py
+++ b/wacruit/src/apps/pre_registration/schemas.py
@@ -46,3 +46,18 @@ class PreRegistrationUserResponse(BaseModel):
 
     class Config:
         orm_mode = True
+
+
+class SendPreRegistrationEmailRequest(BaseModel):
+    subject: str = Field(..., min_length=1, max_length=255)
+    content: str = Field(..., min_length=1)
+    html_content: str | None = None
+    active_only: bool = True
+    pre_registration_id: int | None = None
+
+
+class SendPreRegistrationEmailResponse(BaseModel):
+    total_count: int
+    success_count: int
+    failed_count: int
+    failed_emails: list[str]

--- a/wacruit/src/apps/pre_registration/schemas.py
+++ b/wacruit/src/apps/pre_registration/schemas.py
@@ -1,4 +1,6 @@
 from pydantic import BaseModel
+from pydantic import EmailStr
+from pydantic import Field
 
 
 class CreatePreRegistrationRequest(BaseModel):
@@ -18,6 +20,29 @@ class PreRegistrationResponse(BaseModel):
     url: str
     generation: str
     is_active: bool
+
+    class Config:
+        orm_mode = True
+
+
+class CreatePreRegistrationUserRequest(BaseModel):
+    name: str = Field(..., max_length=50)
+    email: EmailStr
+    phone_number: str = Field(..., max_length=30)
+    university: str | None = Field(default=None, max_length=50)
+    college: str | None = Field(default=None, max_length=50)
+    department: str | None = Field(default=None, max_length=50)
+
+
+class PreRegistrationUserResponse(BaseModel):
+    id: int
+    pre_registration_id: int
+    name: str
+    email: str
+    phone_number: str
+    university: str | None
+    college: str | None
+    department: str | None
 
     class Config:
         orm_mode = True

--- a/wacruit/src/apps/pre_registration/services.py
+++ b/wacruit/src/apps/pre_registration/services.py
@@ -31,7 +31,7 @@ class PreRegistrationService:
             self.pre_registration_repository.get_active_pre_registration()
         )
         if pre_registration is None:
-            raise PreRegistNotActiveException
+            raise PreRegistNotActiveException()
         return pre_registration
 
     def get_pre_registration(self) -> list[PreRegistration]:
@@ -42,7 +42,7 @@ class PreRegistrationService:
         self, req: CreatePreRegistrationRequest
     ) -> PreRegistration:
         if req.is_active and (self.check_active_pre_registration()):
-            raise PreRegistAlreadyExistException
+            raise PreRegistAlreadyExistException()
         to_create = PreRegistration(
             url=req.url, generation=req.generation, is_active=req.is_active
         )
@@ -58,9 +58,17 @@ class PreRegistrationService:
             pre_registration_id
         )
         if pre_registration is None:
-            raise PreRegistNotExistException
-        if req.is_active and (self.check_active_pre_registration()):
-            raise PreRegistAlreadyExistException
+            raise PreRegistNotExistException()
+
+        active_pre_registration = (
+            self.pre_registration_repository.get_active_pre_registration()
+        )
+        if (
+            req.is_active
+            and active_pre_registration is not None
+            and active_pre_registration.id != pre_registration_id
+        ):
+            raise PreRegistAlreadyExistException()
 
         for key, value in req.dict(exclude_none=True).items():
             setattr(pre_registration, key, value)
@@ -73,5 +81,5 @@ class PreRegistrationService:
             pre_registration_id
         )
         if pre_registration is None:
-            raise PreRegistNotExistException
+            raise PreRegistNotExistException()
         self.pre_registration_repository.delete_pre_registration(pre_registration_id)

--- a/wacruit/src/apps/pre_registration/services.py
+++ b/wacruit/src/apps/pre_registration/services.py
@@ -3,6 +3,9 @@ from typing import Annotated
 from fastapi import Depends
 from sqlalchemy.exc import IntegrityError
 
+from wacruit.src.apps.mail.exceptions import MailConfigException
+from wacruit.src.apps.mail.exceptions import MailSendFailedException
+from wacruit.src.apps.mail.services import EmailService
 from wacruit.src.apps.pre_registration.exceptions import PreRegistAlreadyExistException
 from wacruit.src.apps.pre_registration.exceptions import PreRegistNotActiveException
 from wacruit.src.apps.pre_registration.exceptions import PreRegistNotExistException
@@ -15,6 +18,8 @@ from wacruit.src.apps.pre_registration.repositories import PreRegistrationReposi
 from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationRequest
 from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationUserRequest
 from wacruit.src.apps.pre_registration.schemas import PreRegistrationUserResponse
+from wacruit.src.apps.pre_registration.schemas import SendPreRegistrationEmailRequest
+from wacruit.src.apps.pre_registration.schemas import SendPreRegistrationEmailResponse
 from wacruit.src.apps.pre_registration.schemas import UpdatePreRegistrationRequest
 
 
@@ -22,8 +27,10 @@ class PreRegistrationService:
     def __init__(
         self,
         pre_registration_repository: Annotated[PreRegistrationRepository, Depends()],
+        email_service: Annotated[EmailService, Depends()],
     ):
         self.pre_registration_repository = pre_registration_repository
+        self.email_service = email_service
 
     def check_active_pre_registration(self) -> bool:
         pre_registration = (
@@ -139,3 +146,36 @@ class PreRegistrationService:
             PreRegistrationUserResponse.from_orm(pre_registration_user)
             for pre_registration_user in pre_registration_users
         ]
+
+    def send_email_to_pre_registration_users(
+        self, request: SendPreRegistrationEmailRequest
+    ) -> SendPreRegistrationEmailResponse:
+        pre_registration_users = (
+            self.pre_registration_repository.get_pre_registration_users(
+                pre_registration_id=request.pre_registration_id,
+                active_only=request.active_only,
+                limit=None,
+                offset=0,
+            )
+        )
+
+        failed_emails: list[str] = []
+        for pre_registration_user in pre_registration_users:
+            try:
+                self.email_service.send_email(
+                    to_email=pre_registration_user.email,
+                    subject=request.subject,
+                    content=request.content,
+                    html_content=request.html_content,
+                )
+            except (MailConfigException, MailSendFailedException):
+                failed_emails.append(pre_registration_user.email)
+
+        total_count = len(pre_registration_users)
+        failed_count = len(failed_emails)
+        return SendPreRegistrationEmailResponse(
+            total_count=total_count,
+            success_count=total_count - failed_count,
+            failed_count=failed_count,
+            failed_emails=failed_emails,
+        )

--- a/wacruit/src/apps/pre_registration/services.py
+++ b/wacruit/src/apps/pre_registration/services.py
@@ -1,13 +1,20 @@
 from typing import Annotated
 
 from fastapi import Depends
+from sqlalchemy.exc import IntegrityError
 
 from wacruit.src.apps.pre_registration.exceptions import PreRegistAlreadyExistException
 from wacruit.src.apps.pre_registration.exceptions import PreRegistNotActiveException
 from wacruit.src.apps.pre_registration.exceptions import PreRegistNotExistException
+from wacruit.src.apps.pre_registration.exceptions import (
+    PreRegistUserAlreadyExistException,
+)
 from wacruit.src.apps.pre_registration.models import PreRegistration
+from wacruit.src.apps.pre_registration.models import PreRegistrationUser
 from wacruit.src.apps.pre_registration.repositories import PreRegistrationRepository
 from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationRequest
+from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationUserRequest
+from wacruit.src.apps.pre_registration.schemas import PreRegistrationUserResponse
 from wacruit.src.apps.pre_registration.schemas import UpdatePreRegistrationRequest
 
 
@@ -46,10 +53,13 @@ class PreRegistrationService:
         to_create = PreRegistration(
             url=req.url, generation=req.generation, is_active=req.is_active
         )
-        pre_registration = self.pre_registration_repository.create_pre_registration(
-            to_create
-        )
-        return pre_registration
+        try:
+            pre_registration = self.pre_registration_repository.create_pre_registration(
+                to_create
+            )
+            return pre_registration
+        except IntegrityError as exc:
+            raise PreRegistAlreadyExistException() from exc
 
     def update_pre_registration(
         self, pre_registration_id: int, req: UpdatePreRegistrationRequest
@@ -72,9 +82,12 @@ class PreRegistrationService:
 
         for key, value in req.dict(exclude_none=True).items():
             setattr(pre_registration, key, value)
-        return self.pre_registration_repository.update_pre_registration(
-            pre_registration
-        )
+        try:
+            return self.pre_registration_repository.update_pre_registration(
+                pre_registration
+            )
+        except IntegrityError as exc:
+            raise PreRegistAlreadyExistException() from exc
 
     def delete_pre_registration(self, pre_registration_id: int) -> None:
         pre_registration = self.pre_registration_repository.get_pre_registration_by_id(
@@ -83,3 +96,46 @@ class PreRegistrationService:
         if pre_registration is None:
             raise PreRegistNotExistException()
         self.pre_registration_repository.delete_pre_registration(pre_registration_id)
+
+    def create_pre_registration_user(
+        self, request: CreatePreRegistrationUserRequest
+    ) -> PreRegistrationUserResponse:
+        pre_registration = self.get_active_pre_registration()
+        pre_registration_user = PreRegistrationUser(
+            pre_registration_id=pre_registration.id,
+            name=request.name,
+            email=request.email,
+            phone_number=request.phone_number,
+            university=request.university,
+            college=request.college,
+            department=request.department,
+        )
+        try:
+            pre_registration_user = (
+                self.pre_registration_repository.create_pre_registration_user(
+                    pre_registration_user
+                )
+            )
+        except IntegrityError as exc:
+            raise PreRegistUserAlreadyExistException() from exc
+        return PreRegistrationUserResponse.from_orm(pre_registration_user)
+
+    def get_pre_registration_users(
+        self,
+        pre_registration_id: int | None,
+        active_only: bool,
+        limit: int,
+        offset: int,
+    ) -> list[PreRegistrationUserResponse]:
+        pre_registration_users = (
+            self.pre_registration_repository.get_pre_registration_users(
+                pre_registration_id=pre_registration_id,
+                active_only=active_only,
+                limit=limit,
+                offset=offset,
+            )
+        )
+        return [
+            PreRegistrationUserResponse.from_orm(pre_registration_user)
+            for pre_registration_user in pre_registration_users
+        ]

--- a/wacruit/src/apps/pre_registration/services.py
+++ b/wacruit/src/apps/pre_registration/services.py
@@ -1,5 +1,6 @@
 from typing import Annotated
 
+from fastapi import BackgroundTasks
 from fastapi import Depends
 from sqlalchemy.exc import IntegrityError
 
@@ -21,6 +22,8 @@ from wacruit.src.apps.pre_registration.schemas import PreRegistrationUserRespons
 from wacruit.src.apps.pre_registration.schemas import SendPreRegistrationEmailRequest
 from wacruit.src.apps.pre_registration.schemas import SendPreRegistrationEmailResponse
 from wacruit.src.apps.pre_registration.schemas import UpdatePreRegistrationRequest
+
+PRE_REGISTRATION_EMAIL_BATCH_LIMIT = 200
 
 
 class PreRegistrationService:
@@ -148,34 +151,50 @@ class PreRegistrationService:
         ]
 
     def send_email_to_pre_registration_users(
-        self, request: SendPreRegistrationEmailRequest
+        self,
+        request: SendPreRegistrationEmailRequest,
+        background_tasks: BackgroundTasks,
     ) -> SendPreRegistrationEmailResponse:
         pre_registration_users = (
             self.pre_registration_repository.get_pre_registration_users(
                 pre_registration_id=request.pre_registration_id,
                 active_only=request.active_only,
-                limit=None,
+                limit=PRE_REGISTRATION_EMAIL_BATCH_LIMIT,
                 offset=0,
             )
         )
+        recipient_emails = [user.email for user in pre_registration_users]
 
-        failed_emails: list[str] = []
-        for pre_registration_user in pre_registration_users:
+        if recipient_emails:
+            background_tasks.add_task(
+                self._send_email_to_recipients,
+                recipient_emails,
+                request.subject,
+                request.content,
+                request.html_content,
+            )
+
+        return SendPreRegistrationEmailResponse(
+            status="queued",
+            total_count=len(recipient_emails),
+            queued_count=len(recipient_emails),
+            recipient_limit=PRE_REGISTRATION_EMAIL_BATCH_LIMIT,
+        )
+
+    def _send_email_to_recipients(
+        self,
+        recipient_emails: list[str],
+        subject: str,
+        content: str,
+        html_content: str | None,
+    ) -> None:
+        for recipient_email in recipient_emails:
             try:
                 self.email_service.send_email(
-                    to_email=pre_registration_user.email,
-                    subject=request.subject,
-                    content=request.content,
-                    html_content=request.html_content,
+                    to_email=recipient_email,
+                    subject=subject,
+                    content=content,
+                    html_content=html_content,
                 )
             except (MailConfigException, MailSendFailedException):
-                failed_emails.append(pre_registration_user.email)
-
-        total_count = len(pre_registration_users)
-        failed_count = len(failed_emails)
-        return SendPreRegistrationEmailResponse(
-            total_count=total_count,
-            success_count=total_count - failed_count,
-            failed_count=failed_count,
-            failed_emails=failed_emails,
-        )
+                continue

--- a/wacruit/src/apps/pre_registration/views.py
+++ b/wacruit/src/apps/pre_registration/views.py
@@ -3,11 +3,13 @@ from typing import Annotated
 
 from fastapi import APIRouter
 from fastapi import Depends
+from fastapi import Query
 
 from wacruit.src.apps.common.schemas import ListResponse
-from wacruit.src.apps.pre_registration.models import PreRegistration
 from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationRequest
+from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationUserRequest
 from wacruit.src.apps.pre_registration.schemas import PreRegistrationResponse
+from wacruit.src.apps.pre_registration.schemas import PreRegistrationUserResponse
 from wacruit.src.apps.pre_registration.schemas import UpdatePreRegistrationRequest
 from wacruit.src.apps.pre_registration.services import PreRegistrationService
 from wacruit.src.apps.user.dependencies import AdminUser
@@ -15,12 +17,49 @@ from wacruit.src.apps.user.dependencies import AdminUser
 v3_router = APIRouter(prefix="/v3/pre-registration", tags=["preregistration"])
 
 
+class PreRegistrationUserSearchParams:
+    def __init__(
+        self,
+        active_only: bool = False,
+        pre_registration_id: int | None = None,
+        limit: int = Query(50, ge=1, le=200),
+        offset: int = Query(0, ge=0),
+    ) -> None:
+        self.active_only = active_only
+        self.pre_registration_id = pre_registration_id
+        self.limit = limit
+        self.offset = offset
+
+
 @v3_router.get("/active", status_code=HTTPStatus.OK)
 def get_active_pre_registration(
-    pre_registration_service: Annotated[PreRegistrationService, Depends()]
+    pre_registration_service: Annotated[PreRegistrationService, Depends()],
 ) -> PreRegistrationResponse:
     pre_registration = pre_registration_service.get_active_pre_registration()
     return PreRegistrationResponse.from_orm(pre_registration)
+
+
+@v3_router.post("/users", status_code=HTTPStatus.CREATED)
+def create_pre_registration_user(
+    request: CreatePreRegistrationUserRequest,
+    pre_registration_service: Annotated[PreRegistrationService, Depends()],
+) -> PreRegistrationUserResponse:
+    return pre_registration_service.create_pre_registration_user(request)
+
+
+@v3_router.get("/users", status_code=HTTPStatus.OK)
+def get_pre_registration_users(
+    admin_user: AdminUser,
+    pre_registration_service: Annotated[PreRegistrationService, Depends()],
+    params: Annotated[PreRegistrationUserSearchParams, Depends()],
+) -> ListResponse[PreRegistrationUserResponse]:
+    pre_registration_users = pre_registration_service.get_pre_registration_users(
+        pre_registration_id=params.pre_registration_id,
+        active_only=params.active_only,
+        limit=params.limit,
+        offset=params.offset,
+    )
+    return ListResponse(items=pre_registration_users)
 
 
 @v3_router.get("", status_code=HTTPStatus.OK)

--- a/wacruit/src/apps/pre_registration/views.py
+++ b/wacruit/src/apps/pre_registration/views.py
@@ -2,6 +2,7 @@ from http import HTTPStatus
 from typing import Annotated
 
 from fastapi import APIRouter
+from fastapi import BackgroundTasks
 from fastapi import Depends
 from fastapi import Query
 
@@ -49,13 +50,17 @@ def create_pre_registration_user(
     return pre_registration_service.create_pre_registration_user(request)
 
 
-@v3_router.post("/users/email", status_code=HTTPStatus.OK)
+@v3_router.post("/users/email", status_code=HTTPStatus.ACCEPTED)
 def send_email_to_pre_registration_users(
     admin_user: AdminUser,
     request: SendPreRegistrationEmailRequest,
+    background_tasks: BackgroundTasks,
     pre_registration_service: Annotated[PreRegistrationService, Depends()],
 ) -> SendPreRegistrationEmailResponse:
-    return pre_registration_service.send_email_to_pre_registration_users(request)
+    return pre_registration_service.send_email_to_pre_registration_users(
+        request,
+        background_tasks,
+    )
 
 
 @v3_router.get("/users", status_code=HTTPStatus.OK)

--- a/wacruit/src/apps/pre_registration/views.py
+++ b/wacruit/src/apps/pre_registration/views.py
@@ -10,6 +10,8 @@ from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationReque
 from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationUserRequest
 from wacruit.src.apps.pre_registration.schemas import PreRegistrationResponse
 from wacruit.src.apps.pre_registration.schemas import PreRegistrationUserResponse
+from wacruit.src.apps.pre_registration.schemas import SendPreRegistrationEmailRequest
+from wacruit.src.apps.pre_registration.schemas import SendPreRegistrationEmailResponse
 from wacruit.src.apps.pre_registration.schemas import UpdatePreRegistrationRequest
 from wacruit.src.apps.pre_registration.services import PreRegistrationService
 from wacruit.src.apps.user.dependencies import AdminUser
@@ -45,6 +47,15 @@ def create_pre_registration_user(
     pre_registration_service: Annotated[PreRegistrationService, Depends()],
 ) -> PreRegistrationUserResponse:
     return pre_registration_service.create_pre_registration_user(request)
+
+
+@v3_router.post("/users/email", status_code=HTTPStatus.OK)
+def send_email_to_pre_registration_users(
+    admin_user: AdminUser,
+    request: SendPreRegistrationEmailRequest,
+    pre_registration_service: Annotated[PreRegistrationService, Depends()],
+) -> SendPreRegistrationEmailResponse:
+    return pre_registration_service.send_email_to_pre_registration_users(request)
 
 
 @v3_router.get("/users", status_code=HTTPStatus.OK)

--- a/wacruit/src/apps/problem/__init__.py
+++ b/wacruit/src/apps/problem/__init__.py
@@ -1,2 +1,4 @@
 from .views import v1_router
 from .views_v2 import v2_router
+
+__all__ = ["v1_router", "v2_router"]

--- a/wacruit/src/apps/problem/exceptions.py
+++ b/wacruit/src/apps/problem/exceptions.py
@@ -32,7 +32,10 @@ class TestcaseNotFoundException(WacruitException):
     def __init__(self):
         super().__init__(
             status_code=404,
-            detail="테스트케이스를 찾을 수 없습니다.\n지속적으로 문제가 발생하면 관리자에게 문의 부탁드립니다.",
+            detail=(
+                "테스트케이스를 찾을 수 없습니다.\n"
+                "지속적으로 문제가 발생하면 관리자에게 문의 부탁드립니다."
+            ),
         )
 
 

--- a/wacruit/src/apps/problem/models.py
+++ b/wacruit/src/apps/problem/models.py
@@ -6,8 +6,8 @@ from sqlalchemy import Boolean
 from sqlalchemy import DateTime
 from sqlalchemy import ForeignKey
 from sqlalchemy import Numeric
-from sqlalchemy import text
 from sqlalchemy import Text
+from sqlalchemy import text
 from sqlalchemy.dialects.mysql import MEDIUMTEXT
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column

--- a/wacruit/src/apps/problem/repositories.py
+++ b/wacruit/src/apps/problem/repositories.py
@@ -1,10 +1,10 @@
-from typing import Iterable, Sequence
+from typing import Iterable
 
 from fastapi import Depends
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import joinedload
-from sqlalchemy.orm import Session
 
 from wacruit.src.apps.common.enums import CodeSubmissionStatus
 from wacruit.src.apps.common.enums import Language
@@ -12,8 +12,8 @@ from wacruit.src.apps.problem.models import CodeSubmission
 from wacruit.src.apps.problem.models import CodeSubmissionResult
 from wacruit.src.apps.problem.models import Problem
 from wacruit.src.apps.problem.models import Testcase
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class ProblemRepository:
@@ -39,7 +39,7 @@ class ProblemRepository:
         )
         return self.session.execute(query).scalar()
 
-    def create_submission(
+    def create_submission(  # noqa: PLR0913
         self,
         user_id: int,
         problem_id: int,

--- a/wacruit/src/apps/problem/repositories_v2.py
+++ b/wacruit/src/apps/problem/repositories_v2.py
@@ -1,11 +1,12 @@
 from datetime import timedelta
-from typing import Iterable, Sequence, Tuple
+from typing import Iterable
+from typing import Tuple
 
 from fastapi import Depends
 from sqlalchemy import select
+from sqlalchemy.orm import Session
 from sqlalchemy.orm import contains_eager
 from sqlalchemy.orm import joinedload
-from sqlalchemy.orm import Session
 from tenacity import retry
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
@@ -17,8 +18,8 @@ from wacruit.src.apps.problem.models import CodeSubmission
 from wacruit.src.apps.problem.models import CodeSubmissionResult
 from wacruit.src.apps.problem.models import Problem
 from wacruit.src.apps.problem.models import Testcase
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 from wacruit.src.utils.mixins import LoggingMixin
 
 

--- a/wacruit/src/apps/problem/schemas_v2.py
+++ b/wacruit/src/apps/problem/schemas_v2.py
@@ -1,5 +1,3 @@
-from decimal import Decimal
-
 from pydantic import BaseModel
 from pydantic import Field
 

--- a/wacruit/src/apps/problem/services.py
+++ b/wacruit/src/apps/problem/services.py
@@ -1,7 +1,8 @@
 import asyncio
 from decimal import Decimal
 import json
-from typing import AsyncGenerator, Tuple
+from typing import AsyncGenerator
+from typing import Tuple
 
 from fastapi import Depends
 from fastapi import Request
@@ -199,7 +200,12 @@ class ProblemService(LoggingMixin):
 
             except HTTPStatusError as e:
                 data = json.dumps(
-                    {"detail": "채점 서버에 일시적인 문제가 생겼습니다. 잠시 후 다시 시도해주세요."},
+                    {
+                        "detail": (
+                            "채점 서버에 일시적인 문제가 생겼습니다. "
+                            "잠시 후 다시 시도해주세요."
+                        )
+                    },
                     ensure_ascii=False,
                 )
                 event = "error"

--- a/wacruit/src/apps/problem/services_v2.py
+++ b/wacruit/src/apps/problem/services_v2.py
@@ -1,10 +1,7 @@
 import asyncio
-from decimal import Decimal
-from heapq import merge
 import json
-from math import e
-import re
-from typing import AsyncGenerator, Literal, Tuple
+from typing import AsyncGenerator
+from typing import Literal
 
 from fastapi import BackgroundTasks
 from fastapi import Depends
@@ -32,7 +29,6 @@ from wacruit.src.apps.problem.repositories_v2 import ProblemRepository
 from wacruit.src.apps.problem.schemas_v2 import CodeSubmissionResultResponse
 from wacruit.src.apps.problem.schemas_v2 import CodeSubmitRequest
 from wacruit.src.apps.problem.schemas_v2 import ProblemResponse
-from wacruit.src.apps.problem.schemas_v2 import TokenStr
 from wacruit.src.apps.problem.utils_v2 import memory_handi
 from wacruit.src.apps.problem.utils_v2 import time_handi
 from wacruit.src.apps.recruiting.exceptions import RecruitingClosedException
@@ -233,7 +229,12 @@ class ProblemService(LoggingMixin):
 
             except HTTPStatusError as e:
                 data = json.dumps(
-                    {"detail": "채점 서버에 일시적인 문제가 생겼습니다. 잠시 후 다시 시도해주세요."},
+                    {
+                        "detail": (
+                            "채점 서버에 일시적인 문제가 생겼습니다. "
+                            "잠시 후 다시 시도해주세요."
+                        )
+                    },
                     ensure_ascii=False,
                 )
                 event = "error"

--- a/wacruit/src/apps/problem/utils.py
+++ b/wacruit/src/apps/problem/utils.py
@@ -1,5 +1,3 @@
-from decimal import Decimal
-
 from pydantic import BaseModel
 
 from wacruit.src.apps.common.enums import Language

--- a/wacruit/src/apps/problem/utils_v2.py
+++ b/wacruit/src/apps/problem/utils_v2.py
@@ -1,5 +1,3 @@
-from decimal import Decimal
-
 from pydantic import BaseModel
 
 from wacruit.src.apps.hodu.schemas import HoduLanguage

--- a/wacruit/src/apps/project/__init__.py
+++ b/wacruit/src/apps/project/__init__.py
@@ -1,1 +1,5 @@
-from .views import v3_router as router
+from .views import v3_router
+
+router = v3_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/project/exceptions.py
+++ b/wacruit/src/apps/project/exceptions.py
@@ -19,5 +19,6 @@ class ProjectImageNotFoundException(WacruitException):
 class GetPresignedURLException(WacruitException):
     def __init__(self):
         super().__init__(
-            status_code=500, detail="프로젝트 이미지의 presigned URL을 가져오는데 실패했습니다."
+            status_code=500,
+            detail="프로젝트 이미지의 presigned URL을 가져오는데 실패했습니다.",
         )

--- a/wacruit/src/apps/project/models.py
+++ b/wacruit/src/apps/project/models.py
@@ -1,9 +1,7 @@
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import Column
 from sqlalchemy import ForeignKey
-from sqlalchemy import Table
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import relationship
@@ -13,13 +11,12 @@ from wacruit.src.apps.common.enums import ProjectURLType
 from wacruit.src.database.base import DeclarativeBase
 from wacruit.src.database.base import intpk
 from wacruit.src.database.base import str30
-from wacruit.src.database.base import str50
 from wacruit.src.database.base import str100
 from wacruit.src.database.base import str255
 from wacruit.src.database.base import str1500
 
 if TYPE_CHECKING:
-    from wacruit.src.apps.member.models import Member
+    pass
 
 
 class Project(DeclarativeBase):

--- a/wacruit/src/apps/project/repositories.py
+++ b/wacruit/src/apps/project/repositories.py
@@ -1,13 +1,12 @@
 from fastapi import Depends
 from sqlalchemy import update
-from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
+from sqlalchemy.orm import joinedload
 
 from wacruit.src.apps.project.models import Project
 from wacruit.src.apps.project.models import ProjectImage
-from wacruit.src.apps.project.models import ProjectURL
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class ProjectRepository:

--- a/wacruit/src/apps/project/services.py
+++ b/wacruit/src/apps/project/services.py
@@ -5,28 +5,24 @@ from wacruit.src.apps.member.repositories import MemberRepository
 from wacruit.src.apps.portfolio.file.aws.config import storage_config
 from wacruit.src.apps.portfolio.file.aws.s3.client import S3Client
 from wacruit.src.apps.portfolio.file.aws.s3.method import S3PresignedUrlMethod
-from wacruit.src.apps.portfolio.file.aws.s3.utils import (
-    delete_object,
-    generate_presigned_post_url,
-    generate_presigned_url,
-)
-from wacruit.src.apps.project.exceptions import (
-    GetPresignedURLException,
-    ProjectAlreadyExistsException,
-    ProjectImageNotFoundException,
-    ProjectNotFoundException,
-)
-from wacruit.src.apps.project.models import Project, ProjectImage, ProjectURL
+from wacruit.src.apps.portfolio.file.aws.s3.utils import delete_object
+from wacruit.src.apps.portfolio.file.aws.s3.utils import generate_presigned_post_url
+from wacruit.src.apps.portfolio.file.aws.s3.utils import generate_presigned_url
+from wacruit.src.apps.project.exceptions import GetPresignedURLException
+from wacruit.src.apps.project.exceptions import ProjectAlreadyExistsException
+from wacruit.src.apps.project.exceptions import ProjectImageNotFoundException
+from wacruit.src.apps.project.exceptions import ProjectNotFoundException
+from wacruit.src.apps.project.models import Project
+from wacruit.src.apps.project.models import ProjectImage
+from wacruit.src.apps.project.models import ProjectURL
 from wacruit.src.apps.project.repositories import ProjectRepository
-from wacruit.src.apps.project.schemas import (
-    PresignedUrlWithIdResponse,
-    ProjectBriefResponse,
-    ProjectCreateRequest,
-    ProjectDetailResponse,
-    ProjectImageResponse,
-    ProjectLinkDto,
-    ProjectUpdateRequest,
-)
+from wacruit.src.apps.project.schemas import PresignedUrlWithIdResponse
+from wacruit.src.apps.project.schemas import ProjectBriefResponse
+from wacruit.src.apps.project.schemas import ProjectCreateRequest
+from wacruit.src.apps.project.schemas import ProjectDetailResponse
+from wacruit.src.apps.project.schemas import ProjectImageResponse
+from wacruit.src.apps.project.schemas import ProjectLinkDto
+from wacruit.src.apps.project.schemas import ProjectUpdateRequest
 
 _1_MIN = 60
 _10_MIN = 10 * _1_MIN

--- a/wacruit/src/apps/recruiting/__init__.py
+++ b/wacruit/src/apps/recruiting/__init__.py
@@ -1,2 +1,4 @@
 from .views import v1_router
 from .views_v3 import v3_router
+
+__all__ = ["v1_router", "v3_router"]

--- a/wacruit/src/apps/recruiting/models.py
+++ b/wacruit/src/apps/recruiting/models.py
@@ -4,9 +4,9 @@ from typing import TYPE_CHECKING
 
 from sqlalchemy import DateTime
 from sqlalchemy import ForeignKey
-from sqlalchemy import text
 from sqlalchemy import Text
 from sqlalchemy import UniqueConstraint
+from sqlalchemy import text
 from sqlalchemy.orm import Mapped
 from sqlalchemy.orm import mapped_column
 from sqlalchemy.orm import relationship

--- a/wacruit/src/apps/recruiting/views.py
+++ b/wacruit/src/apps/recruiting/views.py
@@ -20,7 +20,7 @@ v1_router = APIRouter(prefix="/v1/recruitings", tags=["recruitings"])
 
 @v1_router.get("")
 def list_recruitings(
-    recruiting_service: Annotated[RecruitingService, Depends()]
+    recruiting_service: Annotated[RecruitingService, Depends()],
 ) -> ListResponse[RecruitingSummaryResponse]:
     return recruiting_service.get_all_recruiting()
 

--- a/wacruit/src/apps/recruiting_info/models.py
+++ b/wacruit/src/apps/recruiting_info/models.py
@@ -1,7 +1,5 @@
-from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import DateTime
 from sqlalchemy import ForeignKey
 from sqlalchemy import UniqueConstraint
 from sqlalchemy.orm import Mapped

--- a/wacruit/src/apps/resume/__init__.py
+++ b/wacruit/src/apps/resume/__init__.py
@@ -1,1 +1,5 @@
-from .views import v1_router as router
+from .views import v1_router
+
+router = v1_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/resume/models.py
+++ b/wacruit/src/apps/resume/models.py
@@ -18,6 +18,9 @@ if TYPE_CHECKING:
     from wacruit.src.apps.user.models import User
 
 
+PREVIEW_LENGTH = 10
+
+
 class ResumeQuestion(DeclarativeBase):
     __tablename__ = "resume_question"
 
@@ -47,8 +50,8 @@ class ResumeQuestion(DeclarativeBase):
             f"recruiting_id={self.recruiting_id}, "
             f"num={self.question_num}, "
             f"limit={self.content_limit}, "
-            f"content={self.content[:10]}"
-            f"{'...' if len(self.content) > 10 else ''}>"
+            f"content={self.content[:PREVIEW_LENGTH]}"
+            f"{'...' if len(self.content) > PREVIEW_LENGTH else ''}>"
         )
 
 
@@ -86,6 +89,6 @@ class ResumeSubmission(DeclarativeBase):
             f"user_id={self.user_id}, "
             f"recruiting_id={self.recruiting_id}, "
             f"question_id={self.question_id}"
-            f"answer={self.answer[:10]}"
-            f"{'...' if len(self.answer) > 10 else ''}>"
+            f"answer={self.answer[:PREVIEW_LENGTH]}"
+            f"{'...' if len(self.answer) > PREVIEW_LENGTH else ''}>"
         )

--- a/wacruit/src/apps/resume/repositories.py
+++ b/wacruit/src/apps/resume/repositories.py
@@ -6,14 +6,14 @@ from sqlalchemy import delete
 from sqlalchemy import select
 from sqlalchemy import update
 from sqlalchemy.exc import InvalidRequestError
-from sqlalchemy.orm import joinedload
 from sqlalchemy.orm import Session
+from sqlalchemy.orm import joinedload
 
 from wacruit.src.apps.resume.exceptions import ResumeNotFound
 from wacruit.src.apps.resume.models import ResumeQuestion
 from wacruit.src.apps.resume.models import ResumeSubmission
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class ResumeRepository:

--- a/wacruit/src/apps/resume/schemas.py
+++ b/wacruit/src/apps/resume/schemas.py
@@ -1,12 +1,9 @@
 from datetime import datetime
-from typing import Sequence
 
 from pydantic import BaseModel
 from pydantic import Field
 
-from wacruit.src.apps.user.models import User
 from wacruit.src.apps.user.schemas import UserDetailResponse
-from wacruit.src.database.base import intpk
 
 
 class ResumeQuestionDto(BaseModel):

--- a/wacruit/src/apps/resume/services.py
+++ b/wacruit/src/apps/resume/services.py
@@ -1,9 +1,8 @@
-from typing import Annotated, Sequence
+from typing import Annotated
+from typing import Sequence
 
 from fastapi import Depends
 
-from wacruit.src.apps.portfolio.file.services_v2 import PortfolioFileService
-from wacruit.src.apps.portfolio.url.services import PortfolioUrlService
 from wacruit.src.apps.recruiting.exceptions import RecruitingClosedException
 from wacruit.src.apps.recruiting.repositories import RecruitingRepository
 from wacruit.src.apps.resume.exceptions import ResumeNotFound

--- a/wacruit/src/apps/resume/views.py
+++ b/wacruit/src/apps/resume/views.py
@@ -2,7 +2,6 @@ from typing import Sequence
 
 from fastapi import APIRouter
 from fastapi import Depends
-from fastapi import Response
 
 from wacruit.src.apps.common.exceptions import ApiDeprecatedException
 from wacruit.src.apps.common.exceptions import responses_from

--- a/wacruit/src/apps/review/__init__.py
+++ b/wacruit/src/apps/review/__init__.py
@@ -1,1 +1,5 @@
-from .views import v3_router as router
+from .views import v3_router
+
+router = v3_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/review/models.py
+++ b/wacruit/src/apps/review/models.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import relationship
 from wacruit.src.database.base import DeclarativeBase
 from wacruit.src.database.base import intpk
 from wacruit.src.database.base import str30
-from wacruit.src.database.base import str255
 from wacruit.src.database.base import str1500
 
 if TYPE_CHECKING:

--- a/wacruit/src/apps/review/repositories.py
+++ b/wacruit/src/apps/review/repositories.py
@@ -2,8 +2,8 @@ from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.review.models import Review
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class ReviewRepository:

--- a/wacruit/src/apps/seminar/__init__.py
+++ b/wacruit/src/apps/seminar/__init__.py
@@ -1,1 +1,5 @@
-from .views import v3_router as router
+from .views import v3_router
+
+router = v3_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/seminar/repositories.py
+++ b/wacruit/src/apps/seminar/repositories.py
@@ -4,8 +4,8 @@ from sqlalchemy import true
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.seminar.models import Seminar
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class SeminarRepository:

--- a/wacruit/src/apps/seminar/schemas.py
+++ b/wacruit/src/apps/seminar/schemas.py
@@ -1,5 +1,4 @@
 from pydantic import BaseModel
-from pydantic import Field
 
 from wacruit.src.apps.common.enums import SeminarType
 

--- a/wacruit/src/apps/seminar/views.py
+++ b/wacruit/src/apps/seminar/views.py
@@ -47,7 +47,7 @@ def update_seminar(
 
 @v3_router.get("/active")
 def get_active_seminar(
-    seminar_service: Annotated[SeminarService, Depends()]
+    seminar_service: Annotated[SeminarService, Depends()],
 ) -> ListResponse:
     seminar_list = seminar_service.get_active_seminar()
 

--- a/wacruit/src/apps/sponsor/__init__.py
+++ b/wacruit/src/apps/sponsor/__init__.py
@@ -1,1 +1,5 @@
-from .views import v3_router as router
+from .views import v3_router
+
+router = v3_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/timeline/__init__.py
+++ b/wacruit/src/apps/timeline/__init__.py
@@ -1,1 +1,5 @@
-from .views import v3_router as router
+from .views import v3_router
+
+router = v3_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/timeline/exceptions.py
+++ b/wacruit/src/apps/timeline/exceptions.py
@@ -3,7 +3,9 @@ from wacruit.src.apps.common.exceptions import WacruitException
 
 class TimelineCategoryNotFoundException(WacruitException):
     def __init__(self):
-        super().__init__(status_code=404, detail="타임라인 카테고리를 찾을 수 없습니다.")
+        super().__init__(
+            status_code=404, detail="타임라인 카테고리를 찾을 수 없습니다."
+        )
 
 
 class TimelineNotFoundException(WacruitException):

--- a/wacruit/src/apps/timeline/repositories.py
+++ b/wacruit/src/apps/timeline/repositories.py
@@ -5,8 +5,8 @@ from sqlalchemy.orm import Session
 from wacruit.src.apps.common.enums import TimelineGroupType
 from wacruit.src.apps.timeline.models import Timeline
 from wacruit.src.apps.timeline.models import TimelineCategory
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class TimelineRepository:

--- a/wacruit/src/apps/timeline/services.py
+++ b/wacruit/src/apps/timeline/services.py
@@ -1,5 +1,3 @@
-from typing import Annotated
-
 from fastapi import Depends
 
 from wacruit.src.apps.common.enums import TimelineGroupType

--- a/wacruit/src/apps/user/__init__.py
+++ b/wacruit/src/apps/user/__init__.py
@@ -1,1 +1,5 @@
-from .views import v1_router as router
+from .views import v1_router
+
+router = v1_router
+
+__all__ = ["router"]

--- a/wacruit/src/apps/user/dependencies.py
+++ b/wacruit/src/apps/user/dependencies.py
@@ -8,9 +8,10 @@ from fastapi.security import HTTPBearer
 from wacruit.src.apps.auth.services import AuthService
 from wacruit.src.apps.user.exceptions import UserPermissionDeniedException
 from wacruit.src.apps.user.models import User
-from wacruit.src.apps.user.repositories import UserRepository
 
-security = HTTPBearer(scheme_name="waffle_token", description="인증을 위한 access token")
+security = HTTPBearer(
+    scheme_name="waffle_token", description="인증을 위한 access token"
+)
 
 
 def get_current_user(

--- a/wacruit/src/apps/user/exceptions.py
+++ b/wacruit/src/apps/user/exceptions.py
@@ -1,5 +1,3 @@
-from fastapi import HTTPException
-
 from wacruit.src.apps.common.exceptions import WacruitException
 
 

--- a/wacruit/src/apps/user/repositories.py
+++ b/wacruit/src/apps/user/repositories.py
@@ -1,11 +1,10 @@
 from fastapi import Depends
 from pydantic import EmailStr
-from sqlalchemy import update
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.user.models import User
-from wacruit.src.database.connection import get_db_session
 from wacruit.src.database.connection import Transaction
+from wacruit.src.database.connection import get_db_session
 
 
 class UserRepository:
@@ -34,9 +33,6 @@ class UserRepository:
 
     def get_user_by_email(self, email: EmailStr) -> User | None:
         return self.session.query(User).filter(User.email == email).first()
-
-    def get_user_by_username(self, username: str) -> User | None:
-        return self.session.query(User).filter(User.username == username).first()
 
     def create_user(self, user: User) -> User:
         with self.transaction:

--- a/wacruit/src/apps/user/services.py
+++ b/wacruit/src/apps/user/services.py
@@ -1,5 +1,3 @@
-from typing import Annotated
-
 from fastapi import Depends
 from sqlalchemy.exc import IntegrityError
 

--- a/wacruit/src/database/base.py
+++ b/wacruit/src/database/base.py
@@ -1,8 +1,8 @@
 from typing import Annotated
 
 from sqlalchemy import String
-from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import DeclarativeBase as Base
+from sqlalchemy.orm import declarative_base
 from sqlalchemy.orm import mapped_column
 
 DeclarativeBase: type[Base] = declarative_base()

--- a/wacruit/src/database/connection.py
+++ b/wacruit/src/database/connection.py
@@ -4,7 +4,6 @@ from fastapi import Depends
 import sqlalchemy
 from sqlalchemy import orm
 from sqlalchemy.orm.session import Session
-from tenacity import Retrying
 
 from wacruit.src.database.config import db_config
 from wacruit.src.settings import settings

--- a/wacruit/src/database/migrations/versions/2026_06_28_1700-8c4d2f1a6b7e_add_pre_registration_active_key.py
+++ b/wacruit/src/database/migrations/versions/2026_06_28_1700-8c4d2f1a6b7e_add_pre_registration_active_key.py
@@ -1,0 +1,63 @@
+"""add pre_registration active key
+
+Revision ID: 8c4d2f1a6b7e
+Revises: 2f9c8e0a1b34
+Create Date: 2026-06-28 17:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "8c4d2f1a6b7e"
+down_revision = "2f9c8e0a1b34"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "pre_registration",
+        sa.Column("active_key", sa.Integer(), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE pre_registration
+        SET active_key = 1
+        WHERE is_active = true
+        ORDER BY id DESC
+        LIMIT 1
+        """
+    )
+    op.execute(
+        """
+        UPDATE pre_registration
+        SET is_active = false
+        WHERE active_key IS NULL AND is_active = true
+        """
+    )
+    op.create_check_constraint(
+        "ck_pre_registration_active_key",
+        "pre_registration",
+        "active_key IS NULL OR active_key = 1",
+    )
+    op.create_unique_constraint(
+        "uk_pre_registration_active",
+        "pre_registration",
+        ["active_key"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uk_pre_registration_active",
+        "pre_registration",
+        type_="unique",
+    )
+    op.drop_constraint(
+        "ck_pre_registration_active_key",
+        "pre_registration",
+        type_="check",
+    )
+    op.drop_column("pre_registration", "active_key")

--- a/wacruit/src/database/migrations/versions/2026_06_29_1000-4b0f9d2e7a61_add_pre_registration_user_table.py
+++ b/wacruit/src/database/migrations/versions/2026_06_29_1000-4b0f9d2e7a61_add_pre_registration_user_table.py
@@ -1,0 +1,45 @@
+"""add pre_registration user table
+
+Revision ID: 4b0f9d2e7a61
+Revises: 8c4d2f1a6b7e
+Create Date: 2026-06-29 10:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "4b0f9d2e7a61"
+down_revision = "8c4d2f1a6b7e"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pre_registration_user",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("pre_registration_id", sa.Integer(), nullable=False),
+        sa.Column("name", sa.String(length=50), nullable=False),
+        sa.Column("email", sa.String(length=255), nullable=False),
+        sa.Column("phone_number", sa.String(length=30), nullable=False),
+        sa.Column("university", sa.String(length=50), nullable=True),
+        sa.Column("college", sa.String(length=50), nullable=True),
+        sa.Column("department", sa.String(length=50), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["pre_registration_id"],
+            ["pre_registration.id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "pre_registration_id",
+            "email",
+            name="uk_pre_registration_user_email",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("pre_registration_user")

--- a/wacruit/src/tests/announcement/conftest.py
+++ b/wacruit/src/tests/announcement/conftest.py
@@ -1,15 +1,11 @@
-from fastapi import FastAPI
-from fastapi.testclient import TestClient
 import pytest
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.announcement.repositories import AnnouncementRepository
 from wacruit.src.apps.announcement.schemas import AnnouncementCreateDto
 from wacruit.src.apps.announcement.services import AnnouncementService
-from wacruit.src.apps.announcement.views import v1_router
 from wacruit.src.apps.common.security import PasswordService
 from wacruit.src.apps.user.models import User
-from wacruit.src.apps.user.repositories import UserRepository
 from wacruit.src.database.connection import Transaction
 
 

--- a/wacruit/src/tests/announcement/test_announcement_service.py
+++ b/wacruit/src/tests/announcement/test_announcement_service.py
@@ -3,6 +3,8 @@ import pytest
 from wacruit.src.apps.announcement.exceptions import AnnouncementNotFound
 from wacruit.src.apps.announcement.services import AnnouncementService
 
+EXPECTED_ANNOUNCEMENT_COUNT = 2
+
 
 def test_create_announcement(
     announcement_service: AnnouncementService, announcement_create_dto
@@ -21,7 +23,7 @@ def test_list_announcements(
     announcement_service.create_announcement(announcement_create_dto)
     announcement_service.create_announcement(announcement_create_dto)
     announcements = announcement_service.list_announcements()
-    assert len(announcements) == 2
+    assert len(announcements) == EXPECTED_ANNOUNCEMENT_COUNT
 
 
 def test_list_pinned_announcements(

--- a/wacruit/src/tests/announcement/test_announcement_views.py
+++ b/wacruit/src/tests/announcement/test_announcement_views.py
@@ -2,6 +2,9 @@ from fastapi.testclient import TestClient
 
 from wacruit.src.apps.user.models import User
 
+HTTP_OK = 200
+HTTP_FORBIDDEN = 403
+
 
 def test_cant_create_announcement_if_not_admin(user: User, test_client: TestClient):
     assert user.is_admin is False
@@ -17,7 +20,7 @@ def test_cant_create_announcement_if_not_admin(user: User, test_client: TestClie
         },
         headers={"Authorization": f"Bearer {token_response['access_token']}"},
     )
-    assert response.status_code == 403
+    assert response.status_code == HTTP_FORBIDDEN
 
 
 def test_can_create_announcement_if_admin(admin_user: User, test_client: TestClient):
@@ -34,6 +37,6 @@ def test_can_create_announcement_if_admin(admin_user: User, test_client: TestCli
         },
         headers={"Authorization": f"Bearer {token_res['access_token']}"},
     )
-    assert response.status_code == 200
+    assert response.status_code == HTTP_OK
     assert response.json()["title"] == "title"
     assert response.json()["content"] == "content"

--- a/wacruit/src/tests/conftest.py
+++ b/wacruit/src/tests/conftest.py
@@ -1,4 +1,7 @@
+import os
 from typing import Iterable
+
+os.environ.setdefault("ENV", "test")
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient

--- a/wacruit/src/tests/faq/conftest.py
+++ b/wacruit/src/tests/faq/conftest.py
@@ -15,8 +15,11 @@ from wacruit.src.database.connection import Transaction
 def created_question(db_session: Session) -> FAQ:
     question = FAQ(
         question="개발 경험이 없는데 지원 가능한가요?",
-        answer="개발을 처음 접하시는 분들도 물론 준회원(Rookies)으로 지원 가능합니다! \
-            와플스튜디오에서 제공하는 세미나를 통해 지식과 협업 경험을 쌓으실 수 있습니다.",
+        answer=(
+            "개발을 처음 접하시는 분들도 물론 준회원(Rookies)으로 지원 가능합니다! "
+            "와플스튜디오에서 제공하는 세미나를 통해 "
+            "지식과 협업 경험을 쌓으실 수 있습니다."
+        ),
     )
     db_session.add(question)
     db_session.commit()
@@ -27,13 +30,19 @@ def created_question(db_session: Session) -> FAQ:
 def created_questions(db_session: Session) -> List[FAQ]:
     question1 = FAQ(
         question="개발 경험이 없는데 지원 가능한가요?",
-        answer="개발을 처음 접하시는 분들도 물론 준회원(Rookies)으로 지원 가능합니다! \
-            와플스튜디오에서 제공하는 세미나를 통해 지식과 협업 경험을 쌓으실 수 있습니다.",
+        answer=(
+            "개발을 처음 접하시는 분들도 물론 준회원(Rookies)으로 지원 가능합니다! "
+            "와플스튜디오에서 제공하는 세미나를 통해 "
+            "지식과 협업 경험을 쌓으실 수 있습니다."
+        ),
     )
     question2 = FAQ(
         question="저학번/고학번/졸업생인데 지원해도 되나요?",
-        answer="와플스튜디오는 서울대학교에 재학중이거나 졸업했던 누구나, 나이 제한 없이 가입 가능합니다. \
-            다양한 학번으로 구성되어 있어 학번 및 졸업 여부와 상관 없이 지원 가능하니 부담 가지지 말고 지원해주세요!",
+        answer=(
+            "와플스튜디오는 서울대학교에 재학중이거나 졸업했던 누구나, "
+            "나이 제한 없이 가입 가능합니다. 다양한 학번으로 구성되어 있어 "
+            "학번 및 졸업 여부와 상관 없이 지원 가능하니 부담 가지지 말고 지원해주세요!"
+        ),
     )
     db_session.add_all([question1, question2])
     db_session.commit()
@@ -44,8 +53,11 @@ def created_questions(db_session: Session) -> List[FAQ]:
 def create_question_dto() -> CreateQuestionRequest:
     return CreateQuestionRequest(
         question="개발 경험이 없는데 지원 가능한가요?",
-        answer="개발을 처음 접하시는 분들도 물론 준회원(Rookies)으로 지원 가능합니다! \
-            와플스튜디오에서 제공하는 세미나를 통해 지식과 협업 경험을 쌓으실 수 있습니다.",
+        answer=(
+            "개발을 처음 접하시는 분들도 물론 준회원(Rookies)으로 지원 가능합니다! "
+            "와플스튜디오에서 제공하는 세미나를 통해 "
+            "지식과 협업 경험을 쌓으실 수 있습니다."
+        ),
     )
 
 

--- a/wacruit/src/tests/faq/test_faq_service.py
+++ b/wacruit/src/tests/faq/test_faq_service.py
@@ -1,5 +1,3 @@
-from typing import List
-
 import pytest
 
 from wacruit.src.apps.faq.exceptions import QuestionNotFoundException

--- a/wacruit/src/tests/portfolio/file/conftest.py
+++ b/wacruit/src/tests/portfolio/file/conftest.py
@@ -1,4 +1,5 @@
-from datetime import datetime, timedelta
+from datetime import datetime
+from datetime import timedelta
 
 import boto3
 import moto

--- a/wacruit/src/tests/portfolio/url/test_portfolio_url_service.py
+++ b/wacruit/src/tests/portfolio/url/test_portfolio_url_service.py
@@ -62,7 +62,7 @@ def test_list_portfolio_urls(
         url="https://test1.com",
         recruiting_id=recruiting1.id,
     )
-    portfolio2 = portfolio_url_service.create_portfolio_url(
+    portfolio_url_service.create_portfolio_url(
         user_id=user1.id,
         url="https://test2.com",
         recruiting_id=recruiting2.id,

--- a/wacruit/src/tests/pre_registration/conftest.py
+++ b/wacruit/src/tests/pre_registration/conftest.py
@@ -3,12 +3,31 @@ from typing import List
 import pytest
 from sqlalchemy.orm import Session
 
+from wacruit.src.apps.mail.exceptions import MailSendFailedException
+from wacruit.src.apps.mail.services import EmailService
 from wacruit.src.apps.pre_registration.models import PreRegistration
 from wacruit.src.apps.pre_registration.repositories import PreRegistrationRepository
 from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationRequest
 from wacruit.src.apps.pre_registration.schemas import UpdatePreRegistrationRequest
 from wacruit.src.apps.pre_registration.services import PreRegistrationService
 from wacruit.src.database.connection import Transaction
+
+
+class FakeEmailService(EmailService):
+    def __init__(self) -> None:
+        self.sent_emails: list[tuple[str, str, str, str | None]] = []
+        self.failed_emails: set[str] = set()
+
+    def send_email(
+        self,
+        to_email: str,
+        subject: str,
+        content: str,
+        html_content: str | None = None,
+    ) -> None:
+        if to_email in self.failed_emails:
+            raise MailSendFailedException()
+        self.sent_emails.append((to_email, subject, content, html_content))
 
 
 @pytest.fixture
@@ -19,11 +38,18 @@ def pre_registration_repository(db_session: Session) -> PreRegistrationRepositor
 
 
 @pytest.fixture
+def fake_email_service() -> FakeEmailService:
+    return FakeEmailService()
+
+
+@pytest.fixture
 def pre_registration_service(
     pre_registration_repository: PreRegistrationRepository,
+    fake_email_service: FakeEmailService,
 ) -> PreRegistrationService:
     return PreRegistrationService(
-        pre_registration_repository=pre_registration_repository
+        pre_registration_repository=pre_registration_repository,
+        email_service=fake_email_service,
     )
 
 

--- a/wacruit/src/tests/pre_registration/test_pre_resgistration_service.py
+++ b/wacruit/src/tests/pre_registration/test_pre_resgistration_service.py
@@ -1,6 +1,7 @@
 from typing import List
 from typing import cast
 
+from fastapi import BackgroundTasks
 from pydantic import EmailStr
 import pytest
 from sqlalchemy.exc import IntegrityError
@@ -18,6 +19,9 @@ from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationUserR
 from wacruit.src.apps.pre_registration.schemas import PreRegistrationResponse
 from wacruit.src.apps.pre_registration.schemas import SendPreRegistrationEmailRequest
 from wacruit.src.apps.pre_registration.schemas import UpdatePreRegistrationRequest
+from wacruit.src.apps.pre_registration.services import (
+    PRE_REGISTRATION_EMAIL_BATCH_LIMIT,
+)
 from wacruit.src.apps.pre_registration.services import PreRegistrationService
 from wacruit.src.tests.pre_registration.conftest import FakeEmailService
 
@@ -278,7 +282,7 @@ def test_get_pre_registration_users_by_pre_registration_id(
     assert response[0].email == "inactive@example.com"
 
 
-def test_send_email_to_active_pre_registration_users(
+def test_send_email_to_active_pre_registration_users_queues_background_task(
     db_session: Session,
     pre_registration_service: PreRegistrationService,
     fake_email_service: FakeEmailService,
@@ -299,6 +303,7 @@ def test_send_email_to_active_pre_registration_users(
     )
     db_session.add_all([active_user, inactive_user])
     db_session.commit()
+    background_tasks = BackgroundTasks()
 
     response = pre_registration_service.send_email_to_pre_registration_users(
         SendPreRegistrationEmailRequest(
@@ -306,54 +311,62 @@ def test_send_email_to_active_pre_registration_users(
             subject="subject",
             content="content",
             html_content="<p>content</p>",
-        )
+        ),
+        background_tasks,
     )
 
+    assert response.status == "queued"
     assert response.total_count == 1
-    assert response.success_count == 1
-    assert response.failed_count == 0
-    assert response.failed_emails == []
+    assert response.queued_count == 1
+    assert response.recipient_limit == PRE_REGISTRATION_EMAIL_BATCH_LIMIT
+    assert fake_email_service.sent_emails == []
+    assert len(background_tasks.tasks) == 1
+
+    [background_task] = background_tasks.tasks
+    background_task.func(*background_task.args, **background_task.kwargs)
+
     assert fake_email_service.sent_emails == [
         ("active@example.com", "subject", "content", "<p>content</p>")
     ]
 
 
-def test_send_email_to_pre_registration_users_returns_failed_emails(
+def test_send_email_to_pre_registration_users_applies_recipient_cap(
     db_session: Session,
     pre_registration_service: PreRegistrationService,
     fake_email_service: FakeEmailService,
     created_active_pre_registration: PreRegistration,
 ):
-    first_user = PreRegistrationUser(
-        pre_registration_id=created_active_pre_registration.id,
-        name="First User",
-        email="first@example.com",
-        phone_number="010-1111-1111",
+    user_count = PRE_REGISTRATION_EMAIL_BATCH_LIMIT + 1
+    db_session.add_all(
+        [
+            PreRegistrationUser(
+                pre_registration_id=created_active_pre_registration.id,
+                name=f"User {index}",
+                email=f"user-{index}@example.com",
+                phone_number="010-1111-1111",
+            )
+            for index in range(user_count)
+        ]
     )
-    second_user = PreRegistrationUser(
-        pre_registration_id=created_active_pre_registration.id,
-        name="Second User",
-        email="second@example.com",
-        phone_number="010-2222-2222",
-    )
-    db_session.add_all([first_user, second_user])
     db_session.commit()
-    fake_email_service.failed_emails.add("second@example.com")
+    background_tasks = BackgroundTasks()
 
     response = pre_registration_service.send_email_to_pre_registration_users(
         SendPreRegistrationEmailRequest(
             active_only=True,
             subject="subject",
             content="content",
-        )
+        ),
+        background_tasks,
     )
 
-    expected_total_count = 2
+    assert response.status == "queued"
+    assert response.total_count == PRE_REGISTRATION_EMAIL_BATCH_LIMIT
+    assert response.queued_count == PRE_REGISTRATION_EMAIL_BATCH_LIMIT
+    assert response.recipient_limit == PRE_REGISTRATION_EMAIL_BATCH_LIMIT
+    assert fake_email_service.sent_emails == []
 
-    assert response.total_count == expected_total_count
-    assert response.success_count == 1
-    assert response.failed_count == 1
-    assert response.failed_emails == ["second@example.com"]
-    assert fake_email_service.sent_emails == [
-        ("first@example.com", "subject", "content", None)
-    ]
+    [background_task] = background_tasks.tasks
+    background_task.func(*background_task.args, **background_task.kwargs)
+
+    assert len(fake_email_service.sent_emails) == PRE_REGISTRATION_EMAIL_BATCH_LIMIT

--- a/wacruit/src/tests/pre_registration/test_pre_resgistration_service.py
+++ b/wacruit/src/tests/pre_registration/test_pre_resgistration_service.py
@@ -16,8 +16,10 @@ from wacruit.src.apps.pre_registration.models import PreRegistration
 from wacruit.src.apps.pre_registration.models import PreRegistrationUser
 from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationUserRequest
 from wacruit.src.apps.pre_registration.schemas import PreRegistrationResponse
+from wacruit.src.apps.pre_registration.schemas import SendPreRegistrationEmailRequest
 from wacruit.src.apps.pre_registration.schemas import UpdatePreRegistrationRequest
 from wacruit.src.apps.pre_registration.services import PreRegistrationService
+from wacruit.src.tests.pre_registration.conftest import FakeEmailService
 
 
 def test_create_pre_registration(
@@ -274,3 +276,84 @@ def test_get_pre_registration_users_by_pre_registration_id(
     assert len(response) == 1
     assert response[0].pre_registration_id == created_no_active_pre_registration.id
     assert response[0].email == "inactive@example.com"
+
+
+def test_send_email_to_active_pre_registration_users(
+    db_session: Session,
+    pre_registration_service: PreRegistrationService,
+    fake_email_service: FakeEmailService,
+    created_active_pre_registration: PreRegistration,
+    created_no_active_pre_registration: PreRegistration,
+):
+    active_user = PreRegistrationUser(
+        pre_registration_id=created_active_pre_registration.id,
+        name="Active User",
+        email="active@example.com",
+        phone_number="010-1111-1111",
+    )
+    inactive_user = PreRegistrationUser(
+        pre_registration_id=created_no_active_pre_registration.id,
+        name="Inactive User",
+        email="inactive@example.com",
+        phone_number="010-2222-2222",
+    )
+    db_session.add_all([active_user, inactive_user])
+    db_session.commit()
+
+    response = pre_registration_service.send_email_to_pre_registration_users(
+        SendPreRegistrationEmailRequest(
+            active_only=True,
+            subject="subject",
+            content="content",
+            html_content="<p>content</p>",
+        )
+    )
+
+    assert response.total_count == 1
+    assert response.success_count == 1
+    assert response.failed_count == 0
+    assert response.failed_emails == []
+    assert fake_email_service.sent_emails == [
+        ("active@example.com", "subject", "content", "<p>content</p>")
+    ]
+
+
+def test_send_email_to_pre_registration_users_returns_failed_emails(
+    db_session: Session,
+    pre_registration_service: PreRegistrationService,
+    fake_email_service: FakeEmailService,
+    created_active_pre_registration: PreRegistration,
+):
+    first_user = PreRegistrationUser(
+        pre_registration_id=created_active_pre_registration.id,
+        name="First User",
+        email="first@example.com",
+        phone_number="010-1111-1111",
+    )
+    second_user = PreRegistrationUser(
+        pre_registration_id=created_active_pre_registration.id,
+        name="Second User",
+        email="second@example.com",
+        phone_number="010-2222-2222",
+    )
+    db_session.add_all([first_user, second_user])
+    db_session.commit()
+    fake_email_service.failed_emails.add("second@example.com")
+
+    response = pre_registration_service.send_email_to_pre_registration_users(
+        SendPreRegistrationEmailRequest(
+            active_only=True,
+            subject="subject",
+            content="content",
+        )
+    )
+
+    expected_total_count = 2
+
+    assert response.total_count == expected_total_count
+    assert response.success_count == 1
+    assert response.failed_count == 1
+    assert response.failed_emails == ["second@example.com"]
+    assert fake_email_service.sent_emails == [
+        ("first@example.com", "subject", "content", None)
+    ]

--- a/wacruit/src/tests/pre_registration/test_pre_resgistration_service.py
+++ b/wacruit/src/tests/pre_registration/test_pre_resgistration_service.py
@@ -7,6 +7,7 @@ from wacruit.src.apps.pre_registration.exceptions import PreRegistNotActiveExcep
 from wacruit.src.apps.pre_registration.exceptions import PreRegistNotExistException
 from wacruit.src.apps.pre_registration.models import PreRegistration
 from wacruit.src.apps.pre_registration.schemas import PreRegistrationResponse
+from wacruit.src.apps.pre_registration.schemas import UpdatePreRegistrationRequest
 from wacruit.src.apps.pre_registration.services import PreRegistrationService
 
 
@@ -49,7 +50,7 @@ def test_no_active_pre_registration(
     created_no_active_pre_registration: PreRegistration,
 ):
     with pytest.raises(PreRegistNotActiveException):
-        response = pre_registration_service.get_active_pre_registration()
+        pre_registration_service.get_active_pre_registration()
 
 
 def test_get_all_pre_registrations(
@@ -95,3 +96,37 @@ def test_delete_pre_registration_not_exist(
 ):
     with pytest.raises(PreRegistNotExistException):
         pre_registration_service.delete_pre_registration(999)
+
+
+def test_update_active_pre_registration_itself(
+    pre_registration_service: PreRegistrationService,
+    created_active_pre_registration: PreRegistration,
+):
+    request = UpdatePreRegistrationRequest(
+        url="https://wafflestudio.com/24_5_pre_registration_updated",
+        generation="24.5",
+        is_active=True,
+    )
+
+    pre_registration = pre_registration_service.update_pre_registration(
+        created_active_pre_registration.id, request
+    )
+
+    assert (
+        pre_registration.url == "https://wafflestudio.com/24_5_pre_registration_updated"
+    )
+    assert pre_registration.generation == "24.5"
+    assert pre_registration.is_active is True
+
+
+def test_update_pre_registration_to_active_when_other_active_exists(
+    pre_registration_service: PreRegistrationService,
+    created_active_pre_registration: PreRegistration,
+    created_no_active_pre_registration: PreRegistration,
+):
+    request = UpdatePreRegistrationRequest(is_active=True)
+
+    with pytest.raises(PreRegistAlreadyExistException):
+        pre_registration_service.update_pre_registration(
+            created_no_active_pre_registration.id, request
+        )

--- a/wacruit/src/tests/pre_registration/test_pre_resgistration_service.py
+++ b/wacruit/src/tests/pre_registration/test_pre_resgistration_service.py
@@ -1,11 +1,20 @@
 from typing import List
+from typing import cast
 
+from pydantic import EmailStr
 import pytest
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
 
 from wacruit.src.apps.pre_registration.exceptions import PreRegistAlreadyExistException
 from wacruit.src.apps.pre_registration.exceptions import PreRegistNotActiveException
 from wacruit.src.apps.pre_registration.exceptions import PreRegistNotExistException
+from wacruit.src.apps.pre_registration.exceptions import (
+    PreRegistUserAlreadyExistException,
+)
 from wacruit.src.apps.pre_registration.models import PreRegistration
+from wacruit.src.apps.pre_registration.models import PreRegistrationUser
+from wacruit.src.apps.pre_registration.schemas import CreatePreRegistrationUserRequest
 from wacruit.src.apps.pre_registration.schemas import PreRegistrationResponse
 from wacruit.src.apps.pre_registration.schemas import UpdatePreRegistrationRequest
 from wacruit.src.apps.pre_registration.services import PreRegistrationService
@@ -130,3 +139,138 @@ def test_update_pre_registration_to_active_when_other_active_exists(
         pre_registration_service.update_pre_registration(
             created_no_active_pre_registration.id, request
         )
+
+
+def test_pre_registration_active_key_unique_constraint(
+    db_session: Session,
+    created_active_pre_registration: PreRegistration,
+):
+    duplicated_active_pre_registration = PreRegistration(
+        url="https://wafflestudio.com/25_5_pre_registration",
+        generation="25.5",
+        is_active=True,
+    )
+
+    db_session.add(duplicated_active_pre_registration)
+    with pytest.raises(IntegrityError):
+        db_session.commit()
+    db_session.rollback()
+
+
+def test_create_pre_registration_user(
+    pre_registration_service: PreRegistrationService,
+    created_active_pre_registration: PreRegistration,
+):
+    request = CreatePreRegistrationUserRequest(
+        name="Waffle User",
+        email=cast(EmailStr, "waffle@example.com"),
+        phone_number="010-1234-5678",
+        university="Seoul National University",
+        college="Engineering",
+        department="Computer Science",
+    )
+
+    response = pre_registration_service.create_pre_registration_user(request)
+
+    assert response.pre_registration_id == created_active_pre_registration.id
+    assert response.name == "Waffle User"
+    assert response.email == "waffle@example.com"
+    assert response.phone_number == "010-1234-5678"
+    assert response.university == "Seoul National University"
+    assert response.college == "Engineering"
+    assert response.department == "Computer Science"
+
+
+def test_create_pre_registration_user_without_active(
+    pre_registration_service: PreRegistrationService,
+    created_no_active_pre_registration: PreRegistration,
+):
+    request = CreatePreRegistrationUserRequest(
+        name="Waffle User",
+        email=cast(EmailStr, "waffle@example.com"),
+        phone_number="010-1234-5678",
+    )
+
+    with pytest.raises(PreRegistNotActiveException):
+        pre_registration_service.create_pre_registration_user(request)
+
+
+def test_create_duplicate_pre_registration_user(
+    pre_registration_service: PreRegistrationService,
+    created_active_pre_registration: PreRegistration,
+):
+    request = CreatePreRegistrationUserRequest(
+        name="Waffle User",
+        email=cast(EmailStr, "waffle@example.com"),
+        phone_number="010-1234-5678",
+    )
+
+    pre_registration_service.create_pre_registration_user(request)
+    with pytest.raises(PreRegistUserAlreadyExistException):
+        pre_registration_service.create_pre_registration_user(request)
+
+
+def test_get_active_pre_registration_users(
+    db_session: Session,
+    pre_registration_service: PreRegistrationService,
+    created_active_pre_registration: PreRegistration,
+    created_no_active_pre_registration: PreRegistration,
+):
+    active_user = PreRegistrationUser(
+        pre_registration_id=created_active_pre_registration.id,
+        name="Active User",
+        email="active@example.com",
+        phone_number="010-1111-1111",
+    )
+    inactive_user = PreRegistrationUser(
+        pre_registration_id=created_no_active_pre_registration.id,
+        name="Inactive User",
+        email="inactive@example.com",
+        phone_number="010-2222-2222",
+    )
+    db_session.add_all([active_user, inactive_user])
+    db_session.commit()
+
+    response = pre_registration_service.get_pre_registration_users(
+        pre_registration_id=None,
+        active_only=True,
+        limit=50,
+        offset=0,
+    )
+
+    assert len(response) == 1
+    assert response[0].pre_registration_id == created_active_pre_registration.id
+    assert response[0].email == "active@example.com"
+
+
+def test_get_pre_registration_users_by_pre_registration_id(
+    db_session: Session,
+    pre_registration_service: PreRegistrationService,
+    created_active_pre_registration: PreRegistration,
+    created_no_active_pre_registration: PreRegistration,
+):
+    active_user = PreRegistrationUser(
+        pre_registration_id=created_active_pre_registration.id,
+        name="Active User",
+        email="active@example.com",
+        phone_number="010-1111-1111",
+    )
+    inactive_user = PreRegistrationUser(
+        pre_registration_id=created_no_active_pre_registration.id,
+        name="Inactive User",
+        email="inactive@example.com",
+        phone_number="010-2222-2222",
+    )
+    db_session.add_all([active_user, inactive_user])
+    db_session.commit()
+
+    response = pre_registration_service.get_pre_registration_users(
+        pre_registration_id=created_no_active_pre_registration.id,
+        active_only=False,
+        limit=50,
+        offset=0,
+    )
+
+    assert len(response) == 1
+    assert response[0].pre_registration_id == created_no_active_pre_registration.id
+    assert response[0].email == "inactive@example.com"

--- a/wacruit/src/tests/resume/test_resume_service.py
+++ b/wacruit/src/tests/resume/test_resume_service.py
@@ -1,16 +1,11 @@
-from pydantic import EmailStr
 import pytest
-import pytest_mock
 
 from wacruit.src.apps.recruiting.exceptions import RecruitingClosedException
 from wacruit.src.apps.recruiting.models import Recruiting
 from wacruit.src.apps.resume.models import ResumeQuestion
-from wacruit.src.apps.resume.models import ResumeSubmission
 from wacruit.src.apps.resume.schemas import ResumeSubmissionCreateDto
 from wacruit.src.apps.resume.services import ResumeService
 from wacruit.src.apps.user.models import User
-from wacruit.src.apps.user.schemas import UserUpdateInvitationEmailsRequest
-from wacruit.src.apps.user.services import UserService
 
 
 def test_get_questions(

--- a/wacruit/src/tests/seminar/test_seminar_service.py
+++ b/wacruit/src/tests/seminar/test_seminar_service.py
@@ -1,9 +1,6 @@
 from typing import List
 
-import pytest
-
 from wacruit.src.apps.seminar.models import Seminar
-from wacruit.src.apps.seminar.models import SeminarType
 from wacruit.src.apps.seminar.schemas import CreateSeminarRequest
 from wacruit.src.apps.seminar.schemas import UpdateSeminarRequest
 from wacruit.src.apps.seminar.services import SeminarService

--- a/wacruit/src/tests/timeline/conftest.py
+++ b/wacruit/src/tests/timeline/conftest.py
@@ -12,7 +12,6 @@ from wacruit.src.apps.timeline.schemas import TimelineCategoryCreateUpdateReques
 from wacruit.src.apps.timeline.schemas import TimelineCreateRequest
 from wacruit.src.apps.timeline.schemas import TimelineUpdateRequest
 from wacruit.src.apps.timeline.services import TimelineService
-from wacruit.src.apps.user.models import User
 from wacruit.src.database.connection import Transaction
 
 

--- a/wacruit/src/tests/user/conftest.py
+++ b/wacruit/src/tests/user/conftest.py
@@ -2,7 +2,6 @@ import pytest
 from sqlalchemy.orm import Session
 
 from wacruit.src.apps.common.security import PasswordService
-import wacruit.src.apps.problem.models  # nopycln: import
 from wacruit.src.apps.user.models import User
 from wacruit.src.apps.user.repositories import UserRepository
 from wacruit.src.apps.user.services import UserService

--- a/wacruit/src/tests/user/test_user_service.py
+++ b/wacruit/src/tests/user/test_user_service.py
@@ -3,9 +3,7 @@ from typing import cast
 from pydantic import EmailStr
 import pytest
 
-from wacruit.src.apps.common.security import PasswordService
 from wacruit.src.apps.user.exceptions import EmailAlreadyExistsException
-from wacruit.src.apps.user.exceptions import UserAlreadyExistsException
 from wacruit.src.apps.user.exceptions import UserNotFoundException
 from wacruit.src.apps.user.models import User
 from wacruit.src.apps.user.schemas import UserCreateRequest
@@ -159,10 +157,10 @@ def test_partial_update_invitation_emails(
     new_data = cast(dict[str, EmailStr], new_data)
     new_request = UserUpdateInvitationEmailsRequest(**new_data)
     user = user_service.update_invitaion_emails(created_user, new_request)
-    assert (
-        user.github_email == new_data["github_email"]
-    ), "github_email should be updated"
-    assert (
-        user.notion_email == data["notion_email"]
-    ), "notion_email should not be updated"
+    assert user.github_email == new_data["github_email"], (
+        "github_email should be updated"
+    )
+    assert user.notion_email == data["notion_email"], (
+        "notion_email should not be updated"
+    )
     assert user.slack_email == data["slack_email"], "slack_email should not be updated"

--- a/wacruit/src/utils/mixins.py
+++ b/wacruit/src/utils/mixins.py
@@ -1,5 +1,5 @@
-from logging import getLogger
 from logging import Logger
+from logging import getLogger
 
 
 class LoggingMixin:


### PR DESCRIPTION
## Summary

- 사전등록 사용자 정보 수집 API를 추가했습니다.
- 사전등록 사용자 조회 API를 추가했습니다.
- 활성 사전등록은 DB 제약으로 하나만 유지되도록 보강했습니다.
- 사전등록별 이메일 중복 등록을 방지했습니다.
- 사전등록자 대상 일괄 이메일 발송 API를 추가했습니다.
- 프로젝트 전반의 `ruff`, `pyright` 오류를 정리했습니다.

## API

- `POST /api/v3/pre-registration/users`
  - 활성 사전등록에 사용자 정보를 등록합니다.

- `GET /api/v3/pre-registration/users?active_only=true`
  - 활성 사전등록 대상자만 조회합니다.

- `POST /api/v3/pre-registration/users/email`
  - 사전등록자에게 이메일을 일괄 발송하고 성공/실패 결과를 반환합니다.